### PR TITLE
bug: fix ALLOWED_HOSTS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,7 +75,7 @@ USE_CELERY=false
 # ====== Application Configuration ======
 SECRET_KEY=replace-me-with-a-secure-secret-key-in-production
 DEBUG=true
-ALLOWED_HOSTS=localhost,127.0.0.1
+ALLOWED_HOSTS='["localhost","127.0.0.1"]'
 # CORS_ORIGINS=http://localhost:3000,http://localhost:8000
 
 # ====== Logging ======


### PR DESCRIPTION
<!-- © 2025 Murat Unsal — Skyulf Project -->

## Summary

Running the setup instructions with [docker compose](https://www.skyulf.com/manual/guides/platform_setup.html#3a-docker-compose-recommended) has the worker and api instances constantly restarting with pydantic error that `ALLOWED_HOSTS` value parsing fails. This tiny PR fixes it for me.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs only
- [ ] Refactor/maintenance

## Checklist

- [ ] Code builds and basic tests pass locally (or in CI)
- [ ] Added/updated tests where appropriate
- [ ] Updated docs/README where appropriate
- [x] No secrets or sensitive data committed
- [ ] All commits are signed off (DCO) with `git commit -s`

## Screenshots or demo (optional)

## Related issues

Fixes #

## Summary by Sourcery

Bug Fixes:
- Fix ALLOWED_HOSTS value in .env.example so worker and API services start without Pydantic validation errors.