### PR TITLE
082

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Each major/minor series has its own file in the [`changelog/`](changelog/) folde
 
 | Series | File | Status | Description |
 |--------|------|--------|-------------|
-| **0.8.x** | [changelog/0.8.x.md](changelog/0.8.x.md) | Active | PyPI-Ready Packaging skyulf-core 0.6.0 Release & PyPI-Ready Packaging (v0.8.0 — v0.8.1) Dual-Engine Correctness (v0.8.0 — v0.8.1) |
+| **0.8.x** | [changelog/0.8.x.md](changelog/0.8.x.md) | Active | PyPI-Ready Packaging skyulf-core 0.6.0 Release & PyPI-Ready Packaging (v0.8.0 — v0.8.1) Dual-Engine Correctness (v0.8.0 — v0.8.1); Per-Fold Preprocessing Refit, skyulf-core 0.7.0 (v0.8.2) |
 | **0.7.x** | [changelog/0.7.x.md](changelog/0.7.x.md) | Stable | Model Explainability, Segmentation Models & Unified Training Pipeline (v0.7.0 — v0.7.9) |
 | **0.6.x** | [changelog/0.6.x.md](changelog/0.6.x.md) | Stable | Ensemble Models, Security Hardening & Codebase Audit Sweeps (v0.6.0 — v0.6.10) |
 | **0.5.x** | [changelog/0.5.x.md](changelog/0.5.x.md) | Stable | Promote Winner, Branch-Aware Preview & Architecture Improvements |

--- a/backend/ml_pipeline/_execution/engine/_feature_eng.py
+++ b/backend/ml_pipeline/_execution/engine/_feature_eng.py
@@ -14,11 +14,16 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from skyulf.data.dataset import SplitDataset
+from skyulf.modeling.base import extract_xy
+from skyulf.preprocessing.fold_adapter import SPLITTER_STEP_TYPES, FeatureEngineerFoldAdapter
 from skyulf.preprocessing.pipeline import FeatureEngineer
 
+from ...constants import StepType
 from ..schemas import NodeConfig
 
 if TYPE_CHECKING:
+    from skyulf.modeling.fold_preprocessing import FoldPreprocessor
+
     from ...artifacts.store import ArtifactStore
 
 logger = logging.getLogger(__name__)
@@ -270,6 +275,134 @@ class FeatureEngMixin:
         except Exception:
             logger.exception("Failed to bundle transformers with model")
             raise
+
+    def _upstream_fe_chain(
+        self, training_node: NodeConfig
+    ) -> tuple[str, list[tuple[str, list[dict[str, Any]]]]] | None:
+        """Follow single-input ancestors from ``training_node`` up to the data loader.
+
+        Returns ``(loader_node_id, chain)`` where ``chain`` is
+        ``[(node_id, unfitted_step_configs), ...]`` in execution order
+        (feature-engineering node steps plus single-transformer nodes wrapped
+        as one-step pipelines, matching ``_run_transformer``). Returns
+        ``None`` when the upstream graph is not a linear chain of
+        feature-engineering/transformer nodes — merged inputs, a missing
+        loader, or an unsupported node type (training/preview in between).
+        """
+        chain: list[tuple[str, list[dict[str, Any]]]] = []
+        if len(dict.fromkeys(training_node.inputs or [])) > 1:
+            return None
+        current_id = training_node.inputs[0] if training_node.inputs else None
+        while current_id is not None:
+            cfg = self._node_configs.get(current_id)
+            if cfg is None:
+                return None
+            if len(dict.fromkeys(cfg.inputs or [])) > 1:
+                return None
+            if cfg.step_type == StepType.DATA_LOADER:
+                return current_id, list(reversed(chain))
+            if cfg.step_type == StepType.FEATURE_ENGINEERING:
+                chain.append((cfg.node_id, list((cfg.params or {}).get("steps", []))))
+            elif cfg.step_type not in (StepType.TRAINING, "data_preview"):
+                # Single-transformer node, wrapped exactly like _run_transformer does.
+                chain.append(
+                    (
+                        cfg.node_id,
+                        [
+                            {
+                                "name": "step",
+                                "transformer": cfg.step_type,
+                                "params": cfg.params or {},
+                            }
+                        ],
+                    )
+                )
+            else:
+                return None
+            current_id = cfg.inputs[0] if cfg.inputs else None
+        return None
+
+    @staticmethod
+    def _split_train_payload(output: Any, target_col: str) -> tuple[Any, Any]:
+        """Extract the pre-transform ``(X, y)`` train payload from a split output."""
+        train = output.train if isinstance(output, SplitDataset) else output
+        return extract_xy(train, target_col)
+
+    def _resolve_fold_preprocessing(
+        self, training_node: NodeConfig, target_col: str
+    ) -> tuple["FoldPreprocessor", tuple[Any, Any]] | None:
+        """Resolve the per-fold preprocessing adapter + pre-transform train payload (F-15).
+
+        Returns ``(adapter, (X_pre, y_pre))`` so CV/tuning folds slice the rows
+        the adapter was built for, or ``None`` to keep pre-transformed scoring.
+        Falls back with an explicit job-log warning when the upstream graph is
+        not a linear chain or the payload cannot be reconstructed — never
+        fails the run.
+        """
+        warning = None
+        try:
+            resolved = self._upstream_fe_chain(training_node)
+            if resolved is None:
+                warning = (
+                    "upstream graph is not a linear chain (merged branches or unsupported nodes)"
+                )
+                return None
+            loader_id, chain = resolved
+
+            flat: list[tuple[dict[str, Any], str, int, int]] = [
+                (step, node_id, idx, len(steps))
+                for node_id, steps in chain
+                for idx, step in enumerate(steps)
+            ]
+            learning_steps = [
+                step for step, *_ in flat if step.get("transformer") not in SPLITTER_STEP_TYPES
+            ]
+            if not learning_steps:
+                # Only splitters upstream: nothing data-dependent to refit per fold.
+                return None
+
+            splitter_positions = [
+                i
+                for i, (step, *_) in enumerate(flat)
+                if step.get("transformer") in SPLITTER_STEP_TYPES
+            ]
+            if not splitter_positions:
+                # No split at all: the raw loader frame IS the train payload.
+                payload = self._split_train_payload(self.artifact_store.load(loader_id), target_col)
+            else:
+                _step, node_id, idx, total = flat[splitter_positions[-1]]
+                if idx == total - 1:
+                    # The last splitter ends at a node boundary, so its stored
+                    # output artifact is the pre-transform SplitDataset itself.
+                    payload = self._split_train_payload(
+                        self.artifact_store.load(node_id), target_col
+                    )
+                else:
+                    # Splitter + learning steps share one FE node; re-run the
+                    # splitter-only step prefix on the raw loader frame to
+                    # reconstruct the pre-learning train rows.
+                    prefix_steps = [s for s, *_ in flat[: splitter_positions[-1] + 1]]
+                    split_output, _metrics = FeatureEngineer(prefix_steps).fit_transform(
+                        self.artifact_store.load(loader_id)
+                    )
+                    payload = self._split_train_payload(split_output, target_col)
+
+            adapter = FeatureEngineerFoldAdapter(learning_steps, target_column=target_col)
+            self.log(
+                f"Per-fold preprocessing refit enabled: {len(learning_steps)} step(s) "
+                "re-fit inside every CV/tuning fold (scores are leakage-free)."
+            )
+            return adapter, payload
+        except Exception:
+            logger.exception("Failed to resolve per-fold preprocessing")
+            warning = "payload reconstruction failed"
+            return None
+        finally:
+            if warning is not None:
+                self.log(
+                    f"Per-fold preprocessing refit skipped: {warning}; "
+                    "CV/tuning scores may be optimistically biased."
+                )
 
     def _run_feature_engineering(self, node: NodeConfig) -> tuple[str, dict[str, Any]]:
         # Input: DataFrame or SplitDataset (merged when multiple branches feed in).

--- a/backend/ml_pipeline/_execution/engine/_feature_eng.py
+++ b/backend/ml_pipeline/_execution/engine/_feature_eng.py
@@ -385,23 +385,15 @@ class FeatureEngMixin:
                 for node_id, steps in chain
                 for idx, step in enumerate(steps)
             ]
-            learning_steps = [
-                step for step, *_ in flat if step.get("transformer") not in SPLITTER_STEP_TYPES
-            ]
-            if not learning_steps:
-                # Only splitters upstream: nothing data-dependent to refit per fold.
-                return None
-
             splitter_positions = [
                 i
                 for i, (step, *_) in enumerate(flat)
                 if step.get("transformer") in SPLITTER_STEP_TYPES
             ]
             if splitter_positions:
+                last_split = splitter_positions[-1]
                 pre_split_learners = [
-                    step
-                    for step, *_ in flat[: splitter_positions[-1]]
-                    if _step_learns_from_data(step)
+                    step for step, *_ in flat[:last_split] if _step_learns_from_data(step)
                 ]
                 if pre_split_learners:
                     # Reconstructing the pre-transform payload would re-fit these
@@ -416,6 +408,25 @@ class FeatureEngMixin:
                         "cannot be re-fit safely per fold"
                     )
                     return None
+                # Stateless pre-split steps were already applied during payload
+                # reconstruction (or by the upstream node whose artifact is
+                # loaded below); keep them out of the per-fold chain so every
+                # step is applied exactly once.
+                learning_steps = [
+                    step
+                    for step, *_ in flat[last_split + 1 :]
+                    if step.get("transformer") not in SPLITTER_STEP_TYPES
+                ]
+            else:
+                # No split at all: every non-splitter step refits per fold.
+                learning_steps = [
+                    step for step, *_ in flat if step.get("transformer") not in SPLITTER_STEP_TYPES
+                ]
+            if not learning_steps:
+                # Only splitters (and stateless pre-split steps) upstream:
+                # nothing data-dependent to refit per fold.
+                return None
+
             if not splitter_positions:
                 # No split at all: the raw loader frame IS the train payload.
                 payload = self._split_train_payload(self.artifact_store.load(loader_id), target_col)

--- a/backend/ml_pipeline/_execution/engine/_feature_eng.py
+++ b/backend/ml_pipeline/_execution/engine/_feature_eng.py
@@ -14,9 +14,17 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from skyulf.data.dataset import SplitDataset
+from skyulf.leakage import (
+    data_dependent_transformers,
+    is_constant_imputation,
+    is_explicit_column_drop,
+    is_explicit_hash_encoding,
+    is_explicit_missing_indicator,
+)
 from skyulf.modeling.base import extract_xy
 from skyulf.preprocessing.fold_adapter import SPLITTER_STEP_TYPES, FeatureEngineerFoldAdapter
 from skyulf.preprocessing.pipeline import FeatureEngineer
+from skyulf.registry import NodeRegistry
 
 from ...constants import StepType
 from ..schemas import NodeConfig
@@ -27,6 +35,29 @@ if TYPE_CHECKING:
     from ...artifacts.store import ArtifactStore
 
 logger = logging.getLogger(__name__)
+
+
+def _step_learns_from_data(step: dict[str, Any]) -> bool:
+    """Whether a step's ``fit`` reads statistics from the rows it is given.
+
+    Mirrors the leakage gate's per-step verdict (``skyulf.validate_leakage_safety``):
+    the param-aware exemptions for stateless modes come first, then the
+    registry-derived learner list. Unknown transformers fail closed — they
+    cannot be proven stateless, so they are treated as learners.
+    """
+    transformer = str(step.get("transformer") or "")
+    params = step.get("params") or {}
+    if is_explicit_column_drop(transformer, params):
+        return False
+    if is_constant_imputation(transformer, params):
+        return False
+    if is_explicit_missing_indicator(transformer, params):
+        return False
+    if is_explicit_hash_encoding(transformer, params):
+        return False
+    if transformer in data_dependent_transformers():
+        return True
+    return transformer not in NodeRegistry.get_all_metadata()
 
 
 class FeatureEngMixin:
@@ -366,6 +397,25 @@ class FeatureEngMixin:
                 for i, (step, *_) in enumerate(flat)
                 if step.get("transformer") in SPLITTER_STEP_TYPES
             ]
+            if splitter_positions:
+                pre_split_learners = [
+                    step
+                    for step, *_ in flat[: splitter_positions[-1]]
+                    if _step_learns_from_data(step)
+                ]
+                if pre_split_learners:
+                    # Reconstructing the pre-transform payload would re-fit these
+                    # steps on the full frame (held-out rows included), and the
+                    # per-fold adapter would then apply them a second time —
+                    # leaky statistics plus double-transformed features.
+                    names = ", ".join(
+                        sorted({str(step.get("transformer")) for step in pre_split_learners})
+                    )
+                    warning = (
+                        f"data-dependent step(s) before the last splitter ({names}) "
+                        "cannot be re-fit safely per fold"
+                    )
+                    return None
             if not splitter_positions:
                 # No split at all: the raw loader frame IS the train payload.
                 payload = self._split_train_payload(self.artifact_store.load(loader_id), target_col)

--- a/backend/ml_pipeline/_execution/engine/_node_runners.py
+++ b/backend/ml_pipeline/_execution/engine/_node_runners.py
@@ -813,20 +813,13 @@ class NodeRunnersMixin:
         # Ensure data is SplitDataset
         data = self._to_split_dataset(data, target_col)
 
-        # F-15: per-fold preprocessing refit is always attempted. Only the
-        # grid/random strategies can run the fold hook today (halving/optuna
-        # delegate CV to sklearn searchers), and holdout tuning with a
-        # validation split is out of scope — both fall back with an explicit
-        # log line instead of failing the run.
+        # F-15: per-fold preprocessing refit is always attempted. All tuning
+        # strategies support it (grid/random via the engine's fold loop,
+        # halving/optuna via a Pipeline wrapper around the searcher's internal
+        # CV); only holdout tuning with a validation split is out of scope and
+        # falls back with an explicit log line instead of failing the run.
         fold_preprocessing = None
-        strategy = str(tuning_params.get("strategy", "random"))
-        if strategy not in ("grid", "random"):
-            self.log(
-                f"Per-fold preprocessing refit skipped: the '{strategy}' tuning "
-                "strategy runs CV inside sklearn searchers where the fold hook "
-                "can't reach yet; tuning scores may be optimistically biased."
-            )
-        elif data.validation is not None:
+        if data.validation is not None:
             self.log(
                 "Per-fold preprocessing refit skipped: a validation split is "
                 "present (holdout tuning path); scores may be optimistically biased."

--- a/backend/ml_pipeline/_execution/engine/_node_runners.py
+++ b/backend/ml_pipeline/_execution/engine/_node_runners.py
@@ -62,6 +62,7 @@ class NodeRunnersMixin:
     _extract_feature_importances: Any
     _extract_shap_explanation: Any
     _pipeline_has_training_node: Any
+    _resolve_fold_preprocessing: Any
 
     def _record_split_dataset_shape_metrics(
         self, metrics: dict[str, Any], data: SplitDataset, target_col: str
@@ -716,12 +717,18 @@ class NodeRunnersMixin:
         tuning_params: dict[str, Any],
         tuning_result: Any,
         node: NodeConfig,
+        fold_preprocessing: tuple[Any, tuple[Any, Any]] | None = None,
     ) -> dict[str, Any]:
         """Run post-tuning cross-validation with the tuned model's best params.
 
         For ``nested_cv``, the inner CV loop already ran during the search, so
         post-tuning CV only needs the outer evaluation and downgrades to
         ``stratified_k_fold`` (classification) or ``k_fold`` (regression).
+
+        ``fold_preprocessing`` (F-15): ``(adapter, (X_pre, y_pre))`` — CV must
+        slice the pre-transform rows so the per-fold refit stays aligned with
+        the preprocessor; ``data.test`` is kept only so the dataset shape is
+        preserved (cross_validate reads ``.train`` only).
         """
         if not tuning_params.get("cv_enabled", False):
             return {}
@@ -737,10 +744,16 @@ class NodeRunnersMixin:
                 f"Using {post_cv_type} for post-tuning evaluation."
             )
 
+        preprocessing = None
+        cv_data = data
+        if fold_preprocessing is not None:
+            preprocessing, pre_train = fold_preprocessing
+            cv_data = SplitDataset(train=pre_train, test=data.test, validation=None)
+
         self.log("Running cross-validation on tuned model with best parameters...")
         try:
             cv_results = cv_estimator.cross_validate(
-                data,
+                cv_data,
                 target_col,
                 {"params": best_params},
                 n_folds=tuning_params.get("cv_folds", 5),
@@ -749,6 +762,7 @@ class NodeRunnersMixin:
                 random_state=tuning_params.get("cv_random_state", 42),
                 time_column=tuning_params.get("cv_time_column") or None,
                 log_callback=self.log,
+                preprocessing=preprocessing,
             )
             return self._aggregate_cv_metrics(cv_results)
         except Exception:
@@ -799,6 +813,27 @@ class NodeRunnersMixin:
         # Ensure data is SplitDataset
         data = self._to_split_dataset(data, target_col)
 
+        # F-15: per-fold preprocessing refit is always attempted. Only the
+        # grid/random strategies can run the fold hook today (halving/optuna
+        # delegate CV to sklearn searchers), and holdout tuning with a
+        # validation split is out of scope — both fall back with an explicit
+        # log line instead of failing the run.
+        fold_preprocessing = None
+        strategy = str(tuning_params.get("strategy", "random"))
+        if strategy not in ("grid", "random"):
+            self.log(
+                f"Per-fold preprocessing refit skipped: the '{strategy}' tuning "
+                "strategy runs CV inside sklearn searchers where the fold hook "
+                "can't reach yet; tuning scores may be optimistically biased."
+            )
+        elif data.validation is not None:
+            self.log(
+                "Per-fold preprocessing refit skipped: a validation split is "
+                "present (holdout tuning path); scores may be optimistically biased."
+            )
+        else:
+            fold_preprocessing = self._resolve_fold_preprocessing(node, target_col)
+
         def progress_callback(current, total, score=None, params=None):
             msg = f"Tuning progress: Trial {current}/{total}"
             if score is not None:
@@ -810,6 +845,11 @@ class NodeRunnersMixin:
         # 1. Run tuning (TunerCalculator.fit)
         # 2. Refit the best model on the full training set (TunerCalculator.fit)
         # 3. Generate predictions on train/test/val splits (TunerApplier.predict)
+        fit_kwargs: dict[str, Any] = {}
+        if fold_preprocessing is not None:
+            adapter, pre_train = fold_preprocessing
+            fit_kwargs["preprocessing"] = adapter
+            fit_kwargs["preprocessing_train"] = pre_train
         estimator.fit_predict(
             data,
             target_col,
@@ -817,6 +857,7 @@ class NodeRunnersMixin:
             progress_callback=progress_callback,
             log_callback=self.log,
             job_id=job_id,
+            **fit_kwargs,
         )
 
         completion_log = (
@@ -832,7 +873,14 @@ class NodeRunnersMixin:
 
         # Cross-Validation on the tuned/fixed model (using best/fixed params)
         cv_metrics = self._run_tuned_cv(
-            calculator, applier, data, target_col, tuning_params, tuning_result, node
+            calculator,
+            applier,
+            data,
+            target_col,
+            tuning_params,
+            tuning_result,
+            node,
+            fold_preprocessing=fold_preprocessing,
         )
 
         return node.node_id, self._finalize_training_run(

--- a/changelog/0.8.x.md
+++ b/changelog/0.8.x.md
@@ -4,6 +4,83 @@ For the version index, see root [CHANGELOG.md](../CHANGELOG.md).
 
 ---
 
+## v0.8.2 — Per-Fold Preprocessing Refit (CV & Tuning Scores Stop Leaking)
+
+### ⚠️ Breaking — reported scores change
+
+CV and hyperparameter-tuning scores computed after this release are **lower
+than before — because they no longer leak.** Previously, preprocessing
+(imputation means, scaler statistics, target-aware encoders, …) was fitted
+once on the full training split before CV began, so every fold's held-out
+rows influenced the very statistics used to transform them, biasing all
+scores optimistically. Skyulf now re-fits preprocessing inside every CV fold
+and every tuning candidate fold. **Your model did not get worse; the old
+estimate was too high.** Historical run metrics are untouched — only re-runs
+produce the new, honest numbers.
+
+### 🧠 Core — skyulf-core 0.7.0
+
+- New `FoldPreprocessor` protocol and `FeatureEngineerFoldAdapter`
+  (`skyulf.preprocessing.fold_adapter`): reconstructs a fresh
+  `FeatureEngineer` from the step configs per fold — registry reconstruction
+  *is* the clone — and filters splitter steps that already ran upstream.
+- `perform_cross_validation(..., preprocessing=...)` re-fits inside every
+  fold, including nested CV's inner and outer loops;
+  `StatefulEstimator.cross_validate` passes the hook through.
+- The tuning engine re-fits inside every candidate fold for `grid`/`random`
+  search, so tuning and CV can no longer disagree. The final best-model
+  refit still runs the full split through preprocessing once — that is the
+  artifact serving uses. `halving_*`/`optuna` strategies (CV runs inside
+  sklearn searchers) and holdout tuning with `validation_data` reject the
+  hook with an explicit diagnostic instead of silently reporting leaky
+  scores.
+- `StatefulEstimator.fit_predict(..., preprocessing=..., preprocessing_train=...)`
+  routes the pre-transform train payload into the tuning fit so fold slicing
+  stays aligned with the preprocessor; predictions still run on the
+  post-transform splits, so served-model behavior is unchanged.
+- Leakage proofs (both engines): a memorising WOE encoder on a pure-noise
+  target scored disc(ROC-AUC) > 0.75 before; per-fold refit brings CV and
+  tuning back to near chance (< 0.65). Measured end to end: legacy full-split
+  scoring reports CV AUC **0.867** / tuning best score **0.867** on pure
+  noise; per-fold refit reports **0.495 / 0.494** — exactly chance.
+- The tuning engine's NaN/Inf input gate no longer rejects pre-transform
+  payloads: with per-fold refit enabled, NaN in the features is legitimate
+  when the pipeline carries an imputer, which re-runs on each fold's
+  training rows before the model sees the data (target and Inf checks are
+  unchanged).
+
+### 🔧 App — always-on threading (no flag, no toggle)
+
+- The pipeline engine resolves each training node's upstream preprocessing
+  chain and threads the adapter + pre-transform train payload into tuning
+  and post-tuning CV on every run (`_resolve_fold_preprocessing`). When a
+  splitter shares a feature-engineering node with learning steps, the
+  splitter-only step prefix is re-run on the raw loader frame to
+  reconstruct the pre-learning rows.
+- Explicit fallbacks — never a failed run, never a silent leak: merged
+  multi-branch preprocessing, `halving_*`/`optuna` strategies, and datasets
+  with a validation split fall back to pre-transformed scoring with an
+  explicit job-log warning ("scores may be optimistically biased").
+- Every run now logs `Per-fold preprocessing refit enabled/skipped`, so the
+  scoring mode of any job is auditable in its logs.
+- End-to-end test coverage: a leakage-dominated contrast test measures both
+  sides on the same noise-target CSV (legacy full-fit scoring vs the app's
+  refit path), and a stress suite runs the imputer + scaler + target-aware
+  encoder chain across classification, regression and voting/stacking
+  ensembles, with honesty probes on noise targets for each task type.
+
+### 📚 Docs
+
+- `docs/examples/leakage_proof_pandas.md`: the "not covered —
+  cross-validation scores, yet" caveat is replaced by "Covered —
+  cross-validation and tuning scores (Skyulf app)".
+- The F-15 design note
+  (`initiatives/dual-engine-correctness/2026-08-23-f15-per-fold-refit-design.md`)
+  carries an implementation-outcome amendment (opt-in phases skipped,
+  fallback semantics, follow-up for halving/optuna).
+
+---
+
 ## v0.8.1 — Dual-Engine Correctness: Leakage Enforcement, Parity & Experiments
 
 ### 📦 Release

--- a/changelog/0.8.x.md
+++ b/changelog/0.8.x.md
@@ -60,10 +60,15 @@ produce the new, honest numbers.
   splitter-only step prefix is re-run on the raw loader frame to
   reconstruct the pre-learning rows.
 - Explicit fallbacks — never a failed run, never a silent leak: merged
-  multi-branch preprocessing and datasets with a validation split fall back
-  to pre-transformed scoring with an explicit job-log warning ("scores may be
-  optimistically biased"). All single-branch tuning strategies, including
-  `halving_*`/`optuna`, run the refit path.
+  multi-branch preprocessing, datasets with a validation split, chains that
+  change the row count or the target (resampling, row drops) under
+  `halving_*`/`optuna` — an sklearn transformer step can only hand `X`
+  forward, so reshaped rows would lose alignment with `y` — and any graph
+  with a data-dependent step configured before the last splitter (payload
+  reconstruction would re-fit it on the full frame) all fall back to
+  pre-transformed scoring with an explicit job-log warning ("scores may be
+  optimistically biased"). Every other single-branch tuning strategy,
+  including `halving_*`/`optuna`, runs the refit path.
 - Every run now logs `Per-fold preprocessing refit enabled/skipped`, so the
   scoring mode of any job is auditable in its logs.
 - End-to-end test coverage: a leakage-dominated contrast test measures both

--- a/changelog/0.8.x.md
+++ b/changelog/0.8.x.md
@@ -27,13 +27,15 @@ produce the new, honest numbers.
 - `perform_cross_validation(..., preprocessing=...)` re-fits inside every
   fold, including nested CV's inner and outer loops;
   `StatefulEstimator.cross_validate` passes the hook through.
-- The tuning engine re-fits inside every candidate fold for `grid`/`random`
-  search, so tuning and CV can no longer disagree. The final best-model
-  refit still runs the full split through preprocessing once — that is the
-  artifact serving uses. `halving_*`/`optuna` strategies (CV runs inside
-  sklearn searchers) and holdout tuning with `validation_data` reject the
-  hook with an explicit diagnostic instead of silently reporting leaky
-  scores.
+- The tuning engine re-fits inside every candidate fold for **all** search
+  strategies, so tuning and CV can no longer disagree. `grid`/`random` apply
+  the hook in the engine's own fold loop; `halving_*`/`optuna` get it by
+  wrapping preprocessing + model in a sklearn `Pipeline` whose
+  searcher-internal CV drives the refit (`FoldPreprocessingStep`). The final
+  best-model refit still runs the full split through preprocessing once —
+  that is the artifact serving uses. Only holdout tuning with
+  `validation_data` rejects the hook with an explicit diagnostic, since there
+  are no folds to refit around.
 - `StatefulEstimator.fit_predict(..., preprocessing=..., preprocessing_train=...)`
   routes the pre-transform train payload into the tuning fit so fold slicing
   stays aligned with the preprocessor; predictions still run on the
@@ -58,9 +60,10 @@ produce the new, honest numbers.
   splitter-only step prefix is re-run on the raw loader frame to
   reconstruct the pre-learning rows.
 - Explicit fallbacks — never a failed run, never a silent leak: merged
-  multi-branch preprocessing, `halving_*`/`optuna` strategies, and datasets
-  with a validation split fall back to pre-transformed scoring with an
-  explicit job-log warning ("scores may be optimistically biased").
+  multi-branch preprocessing and datasets with a validation split fall back
+  to pre-transformed scoring with an explicit job-log warning ("scores may be
+  optimistically biased"). All single-branch tuning strategies, including
+  `halving_*`/`optuna`, run the refit path.
 - Every run now logs `Per-fold preprocessing refit enabled/skipped`, so the
   scoring mode of any job is auditable in its logs.
 - End-to-end test coverage: a leakage-dominated contrast test measures both
@@ -77,7 +80,9 @@ produce the new, honest numbers.
 - The F-15 design note
   (`initiatives/dual-engine-correctness/2026-08-23-f15-per-fold-refit-design.md`)
   carries an implementation-outcome amendment (opt-in phases skipped,
-  fallback semantics, follow-up for halving/optuna).
+  fallback semantics). The halving/optuna follow-up is implemented in this
+  release via the Pipeline wrapper; merged multi-branch refit remains a
+  tracked follow-up.
 
 ---
 

--- a/changelog/0.8.x.md
+++ b/changelog/0.8.x.md
@@ -58,17 +58,22 @@ produce the new, honest numbers.
   and post-tuning CV on every run (`_resolve_fold_preprocessing`). When a
   splitter shares a feature-engineering node with learning steps, the
   splitter-only step prefix is re-run on the raw loader frame to
-  reconstruct the pre-learning rows.
+  reconstruct the pre-learning rows. Every step is applied exactly once:
+  stateless steps configured before the last splitter stay in the
+  reconstructed payload and are not re-applied by the per-fold chain.
 - Explicit fallbacks — never a failed run, never a silent leak: merged
   multi-branch preprocessing, datasets with a validation split, chains that
-  change the row count or the target (resampling, row drops) under
-  `halving_*`/`optuna` — an sklearn transformer step can only hand `X`
-  forward, so reshaped rows would lose alignment with `y` — and any graph
-  with a data-dependent step configured before the last splitter (payload
-  reconstruction would re-fit it on the full frame) all fall back to
-  pre-transformed scoring with an explicit job-log warning ("scores may be
-  optimistically biased"). Every other single-branch tuning strategy,
-  including `halving_*`/`optuna`, runs the refit path.
+  change the row count or the target (resampling, row drops, target
+  re-encoding) under `halving_*`/`optuna` — an sklearn transformer step can
+  only hand `X` forward, so reshaped rows would lose alignment with `y` —
+  and any graph with a data-dependent step configured before the last
+  splitter (payload reconstruction would re-fit it on the full frame) all
+  fall back to pre-transformed scoring with an explicit job-log warning
+  ("scores may be optimistically biased"). The wrap guard combines the
+  adapter's static `changes_row_count` flag with a runtime alignment probe
+  (fit_transform on a small slice, failing closed), so step types added in
+  the future cannot silently drift past it. Every other single-branch
+  tuning strategy, including `halving_*`/`optuna`, runs the refit path.
 - Every run now logs `Per-fold preprocessing refit enabled/skipped`, so the
   scoring mode of any job is auditable in its logs.
 - End-to-end test coverage: a leakage-dominated contrast test measures both

--- a/docs/examples/leakage_proof_pandas.md
+++ b/docs/examples/leakage_proof_pandas.md
@@ -470,4 +470,23 @@ This guarantee applies per preprocessing step, relative to the split defined in 
 
 **Covered — the pipeline-structure gate.** Every node declares whether its `fit()` learns from the data it is given (`learns_from_data` on its node metadata), and both the standalone diagnostic (`skyulf.validate_leakage_safety`) and the pre-execution gate derive their node lists from that registry — there is no hand-maintained allow-list to drift. A pipeline that fits a data-dependent node before its train/test split is rejected by default (`on_leakage="raise"`; set `"warn"` or `"ignore"` to opt out). Unknown nodes fail closed, and a pipeline with no train/test split at all gets an explicit diagnostic stating that the leakage guarantee does not apply to it. The gate is also *param-aware* for dual-mode nodes: a `DropMissingColumns` node dropping explicitly named columns, a `SimpleImputer` with `strategy="constant"`, a `MissingIndicator` flagging explicitly named columns, a `HashEncoder` given an explicit column list, and target-only Label/Ordinal encoding learn nothing from the rows and are allowed before the split — while their data-learning modes (missing-% threshold, statistic strategies, auto-detected missingness/categorical columns, feature encoding) remain gated. `SkyulfPipeline.fit()` surfaces the same verdict as warnings before training when you fit on an unsplit frame.
 
-**Not covered — cross-validation scores, yet.** CV and hyperparameter tuning do not re-fit preprocessing inside each fold: preprocessing is fitted once on the full training set, so every fold's validation rows influenced the statistics used to transform them. Reported CV and tuning scores are therefore optimistic. Per-fold refitting is planned; until it lands, treat CV/tuning scores as an upper bound rather than a leakage-free estimate.
+**Covered — cross-validation and tuning scores (Skyulf app).** As of
+skyulf-core 0.7.0 the app re-fits preprocessing inside every CV fold and
+every tuning candidate fold (a `FoldPreprocessor` threaded through
+`perform_cross_validation`, `StatefulEstimator.cross_validate` and
+`TuningCalculator.fit`): each fold's statistics are learned from that fold's
+training rows only, so CV and tuning scores are no longer optimistically
+biased. The measured size of that bias in the leakage-dominated case (a
+target-aware WOE encoder over a pure-noise target, 400 rows / 200
+categories): legacy full-split scoring reports a CV AUC of **0.867** and a
+tuning best score of **0.867** — pure memorisation of held-out rows — while
+per-fold refit reports **0.495 / 0.494**, exactly chance. On real-signal
+data the honest scores stay close to the old ones (the drop is the bias
+leaving, not the signal). Two graph shapes fall back to pre-transformed scoring with an
+explicit job-log warning: pipelines whose branches merge before training,
+and the `halving_*`/`optuna` tuning strategies (their CV runs inside sklearn
+searchers where the fold hook can't reach yet — `grid`/`random` are
+covered). Library users calling CV/tuning directly get the same guarantee by
+passing a preprocessor — e.g. `FeatureEngineerFoldAdapter(steps_config,
+target_column)` — via the `preprocessing` parameter; without it, CV/tuning
+scores the pre-transformed data and remains an optimistic estimate.

--- a/docs/examples/leakage_proof_pandas.md
+++ b/docs/examples/leakage_proof_pandas.md
@@ -482,11 +482,18 @@ categories): legacy full-split scoring reports a CV AUC of **0.867** and a
 tuning best score of **0.867** — pure memorisation of held-out rows — while
 per-fold refit reports **0.495 / 0.494**, exactly chance. On real-signal
 data the honest scores stay close to the old ones (the drop is the bias
-leaving, not the signal). Two graph shapes fall back to pre-transformed scoring with an
-explicit job-log warning: pipelines whose branches merge before training,
-and the `halving_*`/`optuna` tuning strategies (their CV runs inside sklearn
-searchers where the fold hook can't reach yet — `grid`/`random` are
-covered). Library users calling CV/tuning directly get the same guarantee by
-passing a preprocessor — e.g. `FeatureEngineerFoldAdapter(steps_config,
-target_column)` — via the `preprocessing` parameter; without it, CV/tuning
-scores the pre-transformed data and remains an optimistic estimate.
+leaving, not the signal). All five tuning strategies are covered:
+`grid`/`random` through the engine's own fold loop, and
+`halving_grid`/`halving_random`/`optuna` through a preprocessing step
+wrapped around the candidate model inside the sklearn/optuna searcher, whose
+searcher-internal CV drives the same fit-on-train-only discipline. Two
+shapes fall back to pre-transformed scoring with an explicit job-log
+warning: pipelines whose branches merge before training, and preprocessing
+chains that change the row count or the target (resampling, row drops) under
+`halving_*`/`optuna` — an sklearn pipeline transformer can only hand `X`
+forward, so the reshaped rows would lose alignment with `y`; the engine
+refuses that wrap rather than silently misalign them. Library users calling
+CV/tuning directly get the same guarantee by passing a preprocessor — e.g.
+`FeatureEngineerFoldAdapter(steps_config, target_column)` — via the
+`preprocessing` parameter; without it, CV/tuning scores the pre-transformed
+data and remains an optimistic estimate.

--- a/initiatives/dual-engine-correctness/2026-08-23-f15-per-fold-refit-design.md
+++ b/initiatives/dual-engine-correctness/2026-08-23-f15-per-fold-refit-design.md
@@ -1,11 +1,35 @@
 # F-15 — Per-Fold Preprocessing Refit: Design Note
 
 **Date:** 2026-08-23
-**Status:** Design approved for planning; implementation is a **separate initiative** (target: core 0.7.0).
+**Status:** **Shipped** — skyulf-core 0.7.0, branch `082` (see amendment below).
 **Mandate:** Leakage-enforcement plan §Phase 4, item 10 — "Deliver a design note first — refit contract,
 performance budget (`n_splits`× preprocessing cost), migration plan for users whose scores will drop,
 and whether to land it opt-in (`refit_preprocessing_per_fold=True`) before flipping the default."
 **Companion:** `2026-08-11-audit-findings.md` §4 (the architectural question) and F-15.
+
+---
+
+## Amendment — implementation outcome (2026-08-23)
+
+Shipped the same day as **always-on**, collapsing the §6 migration phases:
+
+- **No users exist**, so the opt-in → bake → default-flip sequence was skipped; there was no
+  migration to manage. The app (`PipelineEngine`) always resolves and threads the adapter.
+- **No frontend toggle** was built (the planned `refit_preprocessing_per_fold` param was dropped
+  entirely — core keeps `preprocessing=None` only as the "caller already transformed" default).
+- **Fallbacks instead of rejections:** merged-branch graphs, `halving_*`/`optuna` strategies, and
+  datasets with a validation split fall back to pre-transformed scoring with an explicit job-log
+  warning ("scores may be optimistically biased") — never a failed run. Core still raises if the
+  hook is passed into an unsupported path; the app simply doesn't pass it there.
+- **Payload reconstruction** replaced the planned `cv_preprocessing_steps` job-config key: the
+  engine walks the linear upstream chain at training time, re-running the splitter-only step
+  prefix on the raw loader frame (or loading the splitter node's artifact) to obtain the
+  pre-transform train payload.
+- Halving/optuna support is a tracked follow-up (sklearn `Pipeline` wrapper).
+- The `docs/examples/leakage_proof_pandas.md` CV caveat is removed (now "Covered").
+
+Everything else in this note (clone contract, adapter shape, performance budget, semantics,
+test plan) landed as designed.
 
 ---
 
@@ -189,5 +213,5 @@ Your model did not get worse; the old estimate was too high."*
 ---
 
 *Definition-of-Done update:* this note satisfies the leakage-enforcement plan's Phase 4 requirement
-"Phase 4 (CV refit) has a written design note". The docs CV caveat stays in place until Phase 3
-(default flip) lands.
+"Phase 4 (CV refit) has a written design note". The docs CV caveat was removed when F-15 shipped
+always-on (see amendment).

--- a/initiatives/dual-engine-correctness/2026-08-23-f15-per-fold-refit-design.md
+++ b/initiatives/dual-engine-correctness/2026-08-23-f15-per-fold-refit-design.md
@@ -17,15 +17,16 @@ Shipped the same day as **always-on**, collapsing the §6 migration phases:
   migration to manage. The app (`PipelineEngine`) always resolves and threads the adapter.
 - **No frontend toggle** was built (the planned `refit_preprocessing_per_fold` param was dropped
   entirely — core keeps `preprocessing=None` only as the "caller already transformed" default).
-- **Fallbacks instead of rejections:** merged-branch graphs, `halving_*`/`optuna` strategies, and
-  datasets with a validation split fall back to pre-transformed scoring with an explicit job-log
-  warning ("scores may be optimistically biased") — never a failed run. Core still raises if the
-  hook is passed into an unsupported path; the app simply doesn't pass it there.
+- **Fallbacks instead of rejections:** merged-branch graphs and datasets with a validation split
+  fall back to pre-transformed scoring with an explicit job-log warning ("scores may be
+  optimistically biased") — never a failed run. Core still raises if the hook is passed into an
+  unsupported path; the app simply doesn't pass it there.
 - **Payload reconstruction** replaced the planned `cv_preprocessing_steps` job-config key: the
   engine walks the linear upstream chain at training time, re-running the splitter-only step
   prefix on the raw loader frame (or loading the splitter node's artifact) to obtain the
   pre-transform train payload.
-- Halving/optuna support is a tracked follow-up (sklearn `Pipeline` wrapper).
+- Halving/optuna support landed the same release: preprocessing + model are wrapped in an sklearn
+  `Pipeline` (`FoldPreprocessingStep`) whose searcher-internal CV drives the per-fold refit.
 - The `docs/examples/leakage_proof_pandas.md` CV caveat is removed (now "Covered").
 
 Everything else in this note (clone contract, adapter shape, performance budget, semantics,

--- a/skyulf-core/setup.py
+++ b/skyulf-core/setup.py
@@ -7,7 +7,7 @@ long_description = (this_directory / "README.md").read_text(encoding="utf-8")
 
 setup(
     name="skyulf-core",
-    version="0.6.1",
+    version="0.7.0",
     description="The core machine learning library for Skyulf.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/skyulf-core/skyulf/modeling/__init__.py
+++ b/skyulf-core/skyulf/modeling/__init__.py
@@ -31,6 +31,7 @@ from .ensemble import (
     VotingRegressorApplier,
     VotingRegressorCalculator,
 )
+from .fold_preprocessing import FoldPreprocessor
 from .hyperparameters import (
     HyperparameterField,
     get_default_search_space,
@@ -77,6 +78,7 @@ __all__ = [
     "StackingRegressorCalculator",
     "StackingRegressorApplier",
     "perform_cross_validation",
+    "FoldPreprocessor",
     "HyperparameterField",
     "get_hyperparameters",
     "get_default_search_space",

--- a/skyulf-core/skyulf/modeling/_tuning/engine.py
+++ b/skyulf-core/skyulf/modeling/_tuning/engine.py
@@ -3,6 +3,7 @@
 import logging
 import warnings
 from collections.abc import Callable
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
@@ -23,12 +24,14 @@ from sklearn.model_selection import (
     StratifiedKFold,
     TimeSeriesSplit,
 )
+from sklearn.pipeline import Pipeline
 
 from ..._validation import raise_invalid_choice
 from ...engines import SkyulfDataFrame
 from ...engines.sklearn_bridge import SklearnBridge
 from .._sklearn_compat import normalize_logistic_regression_params
 from ..base import BaseModelApplier, BaseModelCalculator
+from .fold_pipeline import FoldPreprocessingStep
 from .schemas import TuningConfig, TuningResult
 
 if TYPE_CHECKING:
@@ -304,9 +307,11 @@ class TuningCalculator(BaseModelCalculator):
         Adapts the generic fit interface to the specific tune method.
 
         ``preprocessing`` (F-15): re-fits the given preprocessor on
-        each candidate fold's training rows during ``grid``/``random`` search,
-        so tuning scores stop leaking held-out rows into preprocessing
-        statistics. When set, the final best-model refit runs the full split
+        each candidate fold's training rows during search, so tuning scores
+        stop leaking held-out rows into preprocessing statistics. The custom
+        ``grid``/``random`` loop applies it directly; ``halving_*``/``optuna``
+        get it via a Pipeline wrapper whose searcher-internal CV drives the
+        refit. When set, the final best-model refit runs the full split
         through the preprocessor once — the artifact serving uses.
         """
         tuning_config = self._build_tuning_config(config)
@@ -1173,6 +1178,15 @@ class TuningCalculator(BaseModelCalculator):
         return trials
 
     @staticmethod
+    def _strip_model_prefix(params: Any) -> Any:
+        """Removes the internal ``model__`` pipeline prefix from extracted params
+        (see ``tune``'s wrapped Pipeline path) so callers see the original
+        search-space keys."""
+        if not isinstance(params, dict):
+            return params
+        return {key.removeprefix("model__"): value for key, value in params.items()}
+
+    @staticmethod
     def _log_final_completion(
         log_callback: Callable[[str], None] | None,
         config: TuningConfig,
@@ -1208,19 +1222,11 @@ class TuningCalculator(BaseModelCalculator):
         """
         Runs hyperparameter tuning.
         """
-        if preprocessing is not None:
-            if config.strategy not in ("grid", "random"):
-                raise ValueError(
-                    "Per-fold preprocessing refit currently supports only the 'grid' and "
-                    f"'random' tuning strategies, got {config.strategy!r}: the other "
-                    "strategies run their CV inside sklearn searchers where the per-fold "
-                    "hook cannot reach. Disable the flag or switch strategies."
-                )
-            if validation_data is not None:
-                raise ValueError(
-                    "Per-fold preprocessing refit is not supported with validation_data "
-                    "holdout tuning. Disable the flag or remove the validation input."
-                )
+        if preprocessing is not None and validation_data is not None:
+            raise ValueError(
+                "Per-fold preprocessing refit is not supported with validation_data "
+                "holdout tuning. Disable the flag or remove the validation input."
+            )
         # 1. Prepare Estimator
         # We need a base estimator. Since our Calculator wraps the class,
         # we need to instantiate the underlying sklearn model with default params.
@@ -1234,6 +1240,27 @@ class TuningCalculator(BaseModelCalculator):
         # ``default_params`` may carry structural args (e.g. an ensemble's
         # resolved ``estimators``); the instantiator filters/routes them safely.
         base_estimator = self._instantiate_model(model_class, self.model_calculator.default_params)
+
+        # halving/optuna searchers run their CV internally, where the engine's
+        # per-fold hook cannot reach; wrap preprocessing + model in a Pipeline
+        # so the searcher's own folds refit the preprocessor (F-15).
+        wrapped = preprocessing is not None
+        estimator: Any = base_estimator
+        search_config = config
+        if wrapped:
+            estimator = Pipeline(
+                [
+                    ("preprocessing", FoldPreprocessingStep(preprocessing)),
+                    ("model", base_estimator),
+                ]
+            )
+            # Search-space keys must route through the pipeline to the model step.
+            search_config = replace(
+                config,
+                search_space={
+                    f"model__{key}": values for key, values in (config.search_space or {}).items()
+                },
+            )
 
         # 2. Prepare Splitter
         # If validation data is provided, use PredefinedSplit to train on X and validate on validation_data
@@ -1263,11 +1290,11 @@ class TuningCalculator(BaseModelCalculator):
             )
         elif config.strategy in ["halving_grid", "halving_random"]:
             searcher = self._build_halving_searcher(
-                config, base_estimator, cv, metric, log_callback
+                search_config, estimator, cv, metric, log_callback
             )
         elif config.strategy == "optuna":
             searcher = self._build_optuna_searcher(
-                config, base_estimator, cv, metric, progress_callback, log_callback
+                search_config, estimator, cv, metric, progress_callback, log_callback
             )
         else:
             raise_invalid_choice(
@@ -1277,9 +1304,15 @@ class TuningCalculator(BaseModelCalculator):
             )
 
         # 4. Run Search
-        # Ensure numpy
-        X_arr = self._to_numpy(X_for_search)
-        y_arr = self._to_numpy(y_for_search)
+        # The wrapped pipeline needs named frames (the adapter rebuilds a real
+        # FeatureEngineer); numpy conversion would strip column names.
+        if wrapped:
+            if preprocessing_frames is not None:
+                X_for_search, y_for_search = preprocessing_frames
+            X_arr, y_arr = X_for_search, y_for_search
+        else:
+            X_arr = self._to_numpy(X_for_search)
+            y_arr = self._to_numpy(y_for_search)
         self._execute_search(searcher, X_arr, y_arr, config)
 
         # 5. Extract Results
@@ -1287,6 +1320,11 @@ class TuningCalculator(BaseModelCalculator):
 
         # Collect trials
         trials = self._collect_trials(searcher, config)
+        if wrapped:
+            best_params = self._strip_model_prefix(best_params)
+            trials = [
+                {**trial, "params": self._strip_model_prefix(trial["params"])} for trial in trials
+            ]
 
         # Final completion log for strategies that don't emit per-trial callbacks
         # (halving_grid / halving_random / optuna). The grid/random branch above

--- a/skyulf-core/skyulf/modeling/_tuning/engine.py
+++ b/skyulf-core/skyulf/modeling/_tuning/engine.py
@@ -1,5 +1,6 @@
 """Hyperparameter Tuner implementation."""
 
+import copy
 import logging
 import warnings
 from collections.abc import Callable
@@ -103,6 +104,38 @@ def _ensure_optuna_loaded() -> bool:
                     "Optuna installed but OptunaSearchCV not found. Install 'optuna-integration'."
                 )
     return HAS_OPTUNA
+
+
+# Rows sampled to probe whether a preprocessor keeps X/y aligned inside the
+# halving/optuna Pipeline wrap (see _preserves_row_and_target_alignment).
+_ALIGNMENT_PROBE_ROWS = 200
+
+
+def _preserves_row_and_target_alignment(preprocessing: Any, frames: tuple[Any, Any] | None) -> bool:
+    """Whether the preprocessor's fit_transform keeps rows and target aligned.
+
+    An sklearn Pipeline transformer can only hand ``X`` to the next step, so
+    the wrap is only valid when the chain preserves the row count and leaves
+    ``y`` untouched. Static step lists drift, so this probes the real
+    implementation on a small slice: any row-count change or target
+    transformation (resampling, row drops, target-only label/ordinal
+    encoding) is detected. Fails closed — a probe that raises refuses the
+    wrap. Without named frames (numpy-only library calls) there is nothing
+    to probe; the caller's static flag is the only check there.
+    """
+    if frames is None:
+        return True
+    X, y = frames
+    try:
+        sample_x, sample_y = X.head(_ALIGNMENT_PROBE_ROWS), y.head(_ALIGNMENT_PROBE_ROWS)
+        X_out, y_out = copy.deepcopy(preprocessing).fit_transform(sample_x, sample_y)
+        if len(X_out) != len(sample_x):
+            return False
+        y_in = SklearnBridge.to_sklearn((sample_x, sample_y))[1]
+        y_probed = SklearnBridge.to_sklearn((X_out, y_out))[1]
+        return y_in.shape == y_probed.shape and bool(np.array_equal(y_in, y_probed))
+    except Exception:
+        return False
 
 
 class TuningCalculator(BaseModelCalculator):
@@ -1248,26 +1281,29 @@ class TuningCalculator(BaseModelCalculator):
         # per-fold hook cannot reach; wrap preprocessing + model in a Pipeline
         # so the searcher's own folds refit the preprocessor (F-15).
         wrapped = preprocessing is not None
-        if (
-            wrapped
-            and config.strategy in ("halving_grid", "halving_random", "optuna")
-            and getattr(preprocessing, "changes_row_count", False)
-        ):
+        if wrapped and config.strategy in ("halving_grid", "halving_random", "optuna"):
             # An sklearn transformer step can only hand X to the next step, so
-            # a chain that resamples or drops rows would leave the model
-            # fitting reshaped X against the original, un-aligned y. The
-            # grid/random custom loop threads the transformed y itself and
-            # stays enabled; the searcher-backed strategies fall back to
-            # pre-transformed scoring with an explicit log instead.
-            wrapped = False
-            if log_callback:
-                log_callback(
-                    "Per-fold preprocessing refit skipped for this tuning strategy: "
-                    "the step chain changes row count or the target (resampling / "
-                    "row drops), which cannot stay aligned inside the searcher's "
-                    "pipeline. Tuning scores the pre-transformed data and may be "
-                    "optimistically biased."
-                )
+            # a chain that resamples, drops rows or transforms the target
+            # would leave the model fitting reshaped X against the original,
+            # un-aligned y. The static flag is a cheap fast path; the probe is
+            # authoritative (it catches any shape-changing step, including
+            # future ones) and fails closed. The grid/random custom loop
+            # threads the transformed y itself and stays enabled; the
+            # searcher-backed strategies fall back to pre-transformed scoring
+            # with an explicit log instead.
+            misaligned = getattr(
+                preprocessing, "changes_row_count", False
+            ) or not _preserves_row_and_target_alignment(preprocessing, preprocessing_frames)
+            if misaligned:
+                wrapped = False
+                if log_callback:
+                    log_callback(
+                        "Per-fold preprocessing refit skipped for this tuning strategy: "
+                        "the step chain changes row count or the target (resampling / "
+                        "row drops / target re-encoding), which cannot stay aligned "
+                        "inside the searcher's pipeline. Tuning scores the "
+                        "pre-transformed data and may be optimistically biased."
+                    )
         estimator: Any = base_estimator
         search_config = config
         if wrapped:

--- a/skyulf-core/skyulf/modeling/_tuning/engine.py
+++ b/skyulf-core/skyulf/modeling/_tuning/engine.py
@@ -3,7 +3,7 @@
 import logging
 import warnings
 from collections.abc import Callable
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pandas as pd
@@ -30,6 +30,9 @@ from ...engines.sklearn_bridge import SklearnBridge
 from .._sklearn_compat import normalize_logistic_regression_params
 from ..base import BaseModelApplier, BaseModelCalculator
 from .schemas import TuningConfig, TuningResult
+
+if TYPE_CHECKING:
+    from ..fold_preprocessing import FoldPreprocessor
 
 logger = logging.getLogger(__name__)
 
@@ -290,14 +293,21 @@ class TuningCalculator(BaseModelCalculator):
         self,
         X: pd.DataFrame | SkyulfDataFrame,
         y: pd.Series | Any,
-        config: dict[str, Any],
+        config: dict[str, Any] | TuningConfig,
         progress_callback: Callable[[int, int, float | None, dict | None], None] | None = None,
         log_callback: Callable[[str], None] | None = None,
         validation_data: tuple[pd.DataFrame | SkyulfDataFrame, pd.Series | Any] | None = None,
+        preprocessing: "FoldPreprocessor | None" = None,
     ) -> Any:
         """
         Fits the tuner (runs tuning).
         Adapts the generic fit interface to the specific tune method.
+
+        ``preprocessing`` (F-15): re-fits the given preprocessor on
+        each candidate fold's training rows during ``grid``/``random`` search,
+        so tuning scores stop leaking held-out rows into preprocessing
+        statistics. When set, the final best-model refit runs the full split
+        through the preprocessor once — the artifact serving uses.
         """
         tuning_config = self._build_tuning_config(config)
 
@@ -324,12 +334,15 @@ class TuningCalculator(BaseModelCalculator):
             model_cls is not None
             and getattr(model_cls, "__name__", "") in self._MISSING_NATIVE_MODEL_CLASSES
         )
+        # With per-fold refit, X is the pre-transform payload: NaN there is
+        # legitimate when the pipeline carries an imputer, which re-runs on
+        # each fold's training rows before the model ever sees the data.
         self._validate_no_nan_inf(
             X_np,
             "Input features (X) contain NaN values. Please use an 'Imputer' node before this model.",
             "Input features (X) contain Infinite values. Please scale or clean your data.",
             "Input features (X) contain missing/NaN values. Please use an 'Imputer' node before this model.",
-            allow_nan=x_allows_nan,
+            allow_nan=x_allows_nan or preprocessing is not None,
         )
         self._validate_no_nan_inf(
             y_np,
@@ -361,6 +374,8 @@ class TuningCalculator(BaseModelCalculator):
                 progress_callback=progress_callback,
                 log_callback=log_callback,
                 validation_data=validation_data_np,
+                preprocessing=preprocessing,
+                preprocessing_frames=(X, y) if preprocessing is not None else None,
             )
         convergence_count = 0
         for w in caught:
@@ -378,8 +393,16 @@ class TuningCalculator(BaseModelCalculator):
             if log_callback:
                 log_callback(conv_msg)
 
-        # Refit the best model on the full dataset
-        model = self._refit_best_model(tuning_result, tuning_config, X_np, y_np, log_callback)
+        # Refit the best model on the full dataset. With per-fold refit
+        # enabled, the full dataset is the full-split frame run once through
+        # the preprocessor — the same artifact the folds were scored against
+        # and what serving will use for predictions.
+        if preprocessing is not None:
+            X_refit_frame, y_refit_frame = preprocessing.fit_transform(X, y)
+            X_refit, y_refit = SklearnBridge.to_sklearn((X_refit_frame, y_refit_frame))
+        else:
+            X_refit, y_refit = X_np, y_np
+        model = self._refit_best_model(tuning_result, tuning_config, X_refit, y_refit, log_callback)
 
         return (model, tuning_result)
 
@@ -617,6 +640,7 @@ class TuningCalculator(BaseModelCalculator):
         y_for_search: Any,
         metric: str,
         log_callback: Callable[[str], None] | None,
+        preprocessing: "FoldPreprocessor | None" = None,
     ) -> float:
         """Cross-validates one grid/random-search candidate and returns its mean fold score.
 
@@ -646,6 +670,7 @@ class TuningCalculator(BaseModelCalculator):
                 val_idx=val_idx,
                 metric=metric,
                 log_callback=log_callback,
+                preprocessing=preprocessing,
             )
             fold_scores.append(score)
 
@@ -668,6 +693,7 @@ class TuningCalculator(BaseModelCalculator):
         val_idx: Any,
         metric: str,
         log_callback: Callable[[str], None] | None,
+        preprocessing: "FoldPreprocessor | None" = None,
     ) -> float:
         """Fits one candidate on a single CV fold and returns its score, or ``-inf`` on failure.
 
@@ -683,6 +709,13 @@ class TuningCalculator(BaseModelCalculator):
         # Instantiate and Fit
         # Note: We must handle potential errors (e.g. incompatible params)
         try:
+            # F-15: refit preprocessing inside the fold so its statistics
+            # never see this fold's held-out rows (inside the try so a
+            # preprocessing failure is contained like a model-fit failure).
+            if preprocessing is not None:
+                X_train_fold, y_train_fold = preprocessing.fit_transform(X_train_fold, y_train_fold)
+                X_val_fold, y_val_fold = preprocessing.transform(X_val_fold, y_val_fold)
+
             model = self._instantiate_model(
                 model_class,
                 {**self.model_calculator.default_params, **params},
@@ -733,6 +766,7 @@ class TuningCalculator(BaseModelCalculator):
         metric: str,
         progress_callback: Callable[[int, int, float | None, dict | None], None] | None,
         log_callback: Callable[[str], None] | None,
+        preprocessing: "FoldPreprocessor | None" = None,
     ) -> tuple[list[dict[str, Any]], float, dict[str, Any] | None]:
         """Evaluates every candidate via CV, emitting progress/log callbacks, and tracks the best.
 
@@ -751,7 +785,15 @@ class TuningCalculator(BaseModelCalculator):
             # We instantiate the model with the current candidate parameters and evaluate it
             # using the configured CV strategy.
             mean_score = self._evaluate_candidate_cv(
-                i, params, model_class, cv, X_for_search, y_for_search, metric, log_callback
+                i,
+                params,
+                model_class,
+                cv,
+                X_for_search,
+                y_for_search,
+                metric,
+                log_callback,
+                preprocessing,
             )
 
             if log_callback:
@@ -778,6 +820,7 @@ class TuningCalculator(BaseModelCalculator):
         metric: str,
         progress_callback: Callable[[int, int, float | None, dict | None], None] | None,
         log_callback: Callable[[str], None] | None,
+        preprocessing: "FoldPreprocessor | None" = None,
     ) -> TuningResult:
         """Runs a custom grid/random search loop (instead of sklearn's searchers) so
         per-candidate and per-fold progress/log callbacks can be emitted during tuning.
@@ -803,6 +846,7 @@ class TuningCalculator(BaseModelCalculator):
             metric,
             progress_callback,
             log_callback,
+            preprocessing,
         )
 
         if log_callback:
@@ -1158,10 +1202,25 @@ class TuningCalculator(BaseModelCalculator):
         progress_callback: Callable[[int, int, float | None, dict | None], None] | None = None,
         log_callback: Callable[[str], None] | None = None,
         validation_data: tuple[Any, Any] | None = None,
+        preprocessing: "FoldPreprocessor | None" = None,
+        preprocessing_frames: tuple[Any, Any] | None = None,
     ) -> TuningResult:
         """
         Runs hyperparameter tuning.
         """
+        if preprocessing is not None:
+            if config.strategy not in ("grid", "random"):
+                raise ValueError(
+                    "Per-fold preprocessing refit currently supports only the 'grid' and "
+                    f"'random' tuning strategies, got {config.strategy!r}: the other "
+                    "strategies run their CV inside sklearn searchers where the per-fold "
+                    "hook cannot reach. Disable the flag or switch strategies."
+                )
+            if validation_data is not None:
+                raise ValueError(
+                    "Per-fold preprocessing refit is not supported with validation_data "
+                    "holdout tuning. Disable the flag or remove the validation input."
+                )
         # 1. Prepare Estimator
         # We need a base estimator. Since our Calculator wraps the class,
         # we need to instantiate the underlying sklearn model with default params.
@@ -1186,6 +1245,10 @@ class TuningCalculator(BaseModelCalculator):
         metric = self._resolve_metric(config, y)
 
         if config.strategy in ["grid", "random"]:
+            # Per-fold refit needs named frames (the adapter rebuilds a real
+            # FeatureEngineer), not the numpy arrays used by the searchers.
+            if preprocessing is not None and preprocessing_frames is not None:
+                X_for_search, y_for_search = preprocessing_frames
             # Use custom loop to support progress and log callbacks
             return self._run_grid_or_random_search(
                 X_for_search,
@@ -1196,6 +1259,7 @@ class TuningCalculator(BaseModelCalculator):
                 metric,
                 progress_callback,
                 log_callback,
+                preprocessing,
             )
         elif config.strategy in ["halving_grid", "halving_random"]:
             searcher = self._build_halving_searcher(

--- a/skyulf-core/skyulf/modeling/_tuning/engine.py
+++ b/skyulf-core/skyulf/modeling/_tuning/engine.py
@@ -311,8 +311,11 @@ class TuningCalculator(BaseModelCalculator):
         stop leaking held-out rows into preprocessing statistics. The custom
         ``grid``/``random`` loop applies it directly; ``halving_*``/``optuna``
         get it via a Pipeline wrapper whose searcher-internal CV drives the
-        refit. When set, the final best-model refit runs the full split
-        through the preprocessor once — the artifact serving uses.
+        refit. Chains that change the row count or the target (resampling,
+        row drops) cannot stay aligned inside that wrapper and fall back to
+        pre-transformed scoring with an explicit log instead. When set, the
+        final best-model refit runs the full split through the preprocessor
+        once — the artifact serving uses.
         """
         tuning_config = self._build_tuning_config(config)
 
@@ -1245,6 +1248,26 @@ class TuningCalculator(BaseModelCalculator):
         # per-fold hook cannot reach; wrap preprocessing + model in a Pipeline
         # so the searcher's own folds refit the preprocessor (F-15).
         wrapped = preprocessing is not None
+        if (
+            wrapped
+            and config.strategy in ("halving_grid", "halving_random", "optuna")
+            and getattr(preprocessing, "changes_row_count", False)
+        ):
+            # An sklearn transformer step can only hand X to the next step, so
+            # a chain that resamples or drops rows would leave the model
+            # fitting reshaped X against the original, un-aligned y. The
+            # grid/random custom loop threads the transformed y itself and
+            # stays enabled; the searcher-backed strategies fall back to
+            # pre-transformed scoring with an explicit log instead.
+            wrapped = False
+            if log_callback:
+                log_callback(
+                    "Per-fold preprocessing refit skipped for this tuning strategy: "
+                    "the step chain changes row count or the target (resampling / "
+                    "row drops), which cannot stay aligned inside the searcher's "
+                    "pipeline. Tuning scores the pre-transformed data and may be "
+                    "optimistically biased."
+                )
         estimator: Any = base_estimator
         search_config = config
         if wrapped:

--- a/skyulf-core/skyulf/modeling/_tuning/fold_pipeline.py
+++ b/skyulf-core/skyulf/modeling/_tuning/fold_pipeline.py
@@ -6,6 +6,13 @@ reach. Wrapping preprocessing + model in a ``Pipeline`` lets the searcher's
 own folds drive the refit: ``fit_transform`` sees each fold's training rows,
 ``transform`` sees the held-out rows — the same discipline the custom
 grid/random loop applies.
+
+Because a transformer step can only hand ``X`` to the next step (``y`` is
+threaded through unchanged by the Pipeline), this wrap is only valid for
+preprocessors that keep the rows and the target aligned. The tuning engine
+reads the preprocessor's ``changes_row_count`` flag and refuses the wrap —
+falling back to pre-transformed scoring with an explicit log — when the
+chain resamples or drops rows.
 """
 
 import copy

--- a/skyulf-core/skyulf/modeling/_tuning/fold_pipeline.py
+++ b/skyulf-core/skyulf/modeling/_tuning/fold_pipeline.py
@@ -1,0 +1,47 @@
+"""sklearn-compatible preprocessing step for searcher-internal CV (F-15).
+
+``halving_*`` and ``optuna`` tuning strategies run their cross-validation
+inside sklearn/optuna searchers, where the engine's per-fold hook cannot
+reach. Wrapping preprocessing + model in a ``Pipeline`` lets the searcher's
+own folds drive the refit: ``fit_transform`` sees each fold's training rows,
+``transform`` sees the held-out rows — the same discipline the custom
+grid/random loop applies.
+"""
+
+import copy
+from typing import Any
+
+from sklearn.base import BaseEstimator, TransformerMixin
+
+
+class FoldPreprocessingStep(BaseEstimator, TransformerMixin):
+    """Pipeline step that refits a ``FoldPreprocessor`` on every ``fit``.
+
+    The preprocessor is deep-copied at fit time, so clones made by the
+    searcher (one per candidate) never share fitted state — safe even when
+    the searcher parallelises candidates with ``n_jobs > 1``.
+
+    ``fit_transform`` returns the refit output directly instead of letting
+    ``TransformerMixin`` re-transform the training rows: row-count-changing
+    steps (resampling, row drops) must shape the data the model trains on,
+    while ``transform`` keeps every held-out row (the F-18 discipline).
+    """
+
+    def __init__(self, preprocessor: Any) -> None:
+        self.preprocessor = preprocessor
+
+    def fit(self, X: Any, y: Any = None) -> "FoldPreprocessingStep":
+        worker = copy.deepcopy(self.preprocessor)
+        worker.fit_transform(X, y)
+        self.preprocessor_ = worker
+        return self
+
+    def fit_transform(self, X: Any, y: Any = None, **_fit_params: Any) -> Any:
+        worker = copy.deepcopy(self.preprocessor)
+        transformed, _y = worker.fit_transform(X, y)
+        self.preprocessor_ = worker
+        return transformed
+
+    def transform(self, X: Any) -> Any:
+        transformed, _y = self.preprocessor_.transform(X, None)
+        return transformed

--- a/skyulf-core/skyulf/modeling/_tuning/fold_pipeline.py
+++ b/skyulf-core/skyulf/modeling/_tuning/fold_pipeline.py
@@ -10,9 +10,11 @@ grid/random loop applies.
 Because a transformer step can only hand ``X`` to the next step (``y`` is
 threaded through unchanged by the Pipeline), this wrap is only valid for
 preprocessors that keep the rows and the target aligned. The tuning engine
-reads the preprocessor's ``changes_row_count`` flag and refuses the wrap —
-falling back to pre-transformed scoring with an explicit log — when the
-chain resamples or drops rows.
+refuses the wrap — falling back to pre-transformed scoring with an explicit
+log — when the chain resamples, drops rows, or re-encodes the target: a
+static ``changes_row_count`` flag is the cheap fast path, and a runtime
+alignment probe (fit_transform on a small slice, failing closed) is the
+authoritative check so future step types cannot drift past it.
 """
 
 import copy

--- a/skyulf-core/skyulf/modeling/base.py
+++ b/skyulf-core/skyulf/modeling/base.py
@@ -10,6 +10,7 @@ import polars as pl
 from .._validation import raise_invalid_choice
 from ..data.dataset import SplitDataset
 from ..engines import EngineName, SkyulfDataFrame, get_engine
+from .fold_preprocessing import FoldPreprocessor
 
 logger = logging.getLogger(__name__)
 
@@ -200,6 +201,7 @@ class StatefulEstimator:
         time_column: str | None = None,
         progress_callback: Callable[[int, int], None] | None = None,
         log_callback: Callable[[str], None] | None = None,
+        preprocessing: FoldPreprocessor | None = None,
     ) -> dict[str, Any]:
         """
         Performs cross-validation on the training split.
@@ -222,6 +224,7 @@ class StatefulEstimator:
             time_column=time_column,
             progress_callback=progress_callback,
             log_callback=log_callback,
+            preprocessing=preprocessing,
         )
 
     @staticmethod
@@ -318,9 +321,18 @@ class StatefulEstimator:
         progress_callback: Callable[[int, int], None] | None = None,
         log_callback: Callable[[str], None] | None = None,
         job_id: str = "unknown",
+        preprocessing: FoldPreprocessor | None = None,
+        preprocessing_train: tuple[Any, Any] | None = None,
     ) -> dict[str, pd.Series]:
         """
         Fits the model on training data and returns predictions for all splits.
+
+        ``preprocessing`` (F-15): forwarded to calculators that
+        support per-fold refit (``TuningCalculator``). When set,
+        ``preprocessing_train`` must carry the pre-transform ``(X, y)``
+        payload the calculator should fit/tune on, so fold slicing stays
+        aligned with the preprocessor; predictions still run on this
+        dataset's (post-transform) splits.
         """
         # Handle raw DataFrame or Tuple input by wrapping it in a dummy SplitDataset
         dataset = self._normalize_fit_predict_dataset(dataset, target_column, log_callback)
@@ -334,14 +346,30 @@ class StatefulEstimator:
             validation_data = (X_val, y_val)
 
         # 2. Train Model
-        self.model = self.calculator.fit(
-            X_train,
-            y_train,
-            config,
-            progress_callback=progress_callback,
-            log_callback=log_callback,
-            validation_data=validation_data,
-        )
+        if preprocessing is not None:
+            if preprocessing_train is None:
+                raise ValueError("preprocessing requires the preprocessing_train (X, y) payload")
+            # Only TuningCalculator accepts the hook today; the backend only
+            # passes it when wrapping one, so a narrow cast keeps the generic
+            # calculator interface clean.
+            self.model = cast(Any, self.calculator).fit(
+                preprocessing_train[0],
+                preprocessing_train[1],
+                config,
+                progress_callback=progress_callback,
+                log_callback=log_callback,
+                validation_data=validation_data,
+                preprocessing=preprocessing,
+            )
+        else:
+            self.model = self.calculator.fit(
+                X_train,
+                y_train,
+                config,
+                progress_callback=progress_callback,
+                log_callback=log_callback,
+                validation_data=validation_data,
+            )
 
         # 3. Predict on all splits
         predictions = {}

--- a/skyulf-core/skyulf/modeling/cross_validation.py
+++ b/skyulf-core/skyulf/modeling/cross_validation.py
@@ -17,6 +17,7 @@ from ..engines.sklearn_bridge import SklearnBridge
 
 if TYPE_CHECKING:
     from .base import BaseModelApplier, BaseModelCalculator
+    from .fold_preprocessing import FoldPreprocessor
 
 from ._evaluation.common import sanitize_metrics
 from ._evaluation.metrics import (
@@ -79,6 +80,7 @@ def perform_cross_validation(
     time_column: str | None = None,
     progress_callback: Callable[[int, int], None] | None = None,
     log_callback: Callable[[str], None] | None = None,
+    preprocessing: "FoldPreprocessor | None" = None,
 ) -> dict[str, Any]:
     """
     Performs K-Fold cross-validation.
@@ -96,6 +98,10 @@ def perform_cross_validation(
         time_column: Optional column name for sorting when using time_series_split.
         progress_callback: Optional callback(current_fold, total_folds).
         log_callback: Optional callback for logging messages.
+        preprocessing: Optional per-fold preprocessor (F-15). When given, it is
+            re-fit on each fold's training rows and applied to the held-out rows,
+            so preprocessing statistics never see held-out data. ``None`` means
+            the caller already transformed the data before splitting.
 
     Returns:
         Dict containing aggregated metrics and per-fold details.
@@ -127,6 +133,7 @@ def perform_cross_validation(
             random_state=random_state,
             progress_callback=progress_callback,
             log_callback=log_callback,
+            preprocessing=preprocessing,
         )
 
     # 1. Setup Splitter (delegates to _build_splitter so unknown cv_type
@@ -159,6 +166,7 @@ def perform_cross_validation(
                 n_folds=n_folds,
                 progress_callback=progress_callback,
                 log_callback=log_callback,
+                preprocessing=preprocessing,
             )
         )
 
@@ -205,6 +213,24 @@ def _slice_fold_data(X: Any, y: Any, train_idx: Any, val_idx: Any) -> tuple[Any,
     return X_train_fold, X_val_fold, y_train_fold, y_val_fold
 
 
+def _apply_fold_preprocessing(
+    preprocessing: "FoldPreprocessor | None",
+    X_train: Any,
+    y_train: Any,
+    X_val: Any,
+    y_val: Any,
+) -> tuple[Any, Any, Any, Any]:
+    """Re-fit preprocessing on this fold's training rows and apply it to the held-out rows.
+
+    No-op when ``preprocessing`` is None (data already transformed by caller).
+    """
+    if preprocessing is None:
+        return X_train, y_train, X_val, y_val
+    X_train, y_train = preprocessing.fit_transform(X_train, y_train)
+    X_val, y_val = preprocessing.transform(X_val, y_val)
+    return X_train, y_train, X_val, y_val
+
+
 def _run_cv_fold(
     calculator: "BaseModelCalculator",
     X: Any,
@@ -217,6 +243,7 @@ def _run_cv_fold(
     n_folds: int,
     progress_callback: Callable[[int, int], None] | None,
     log_callback: Callable[[str], None] | None,
+    preprocessing: "FoldPreprocessor | None" = None,
 ) -> dict[str, Any]:
     """Fit and evaluate a single CV fold, reporting progress/logging, and return its result entry."""
     if progress_callback:
@@ -226,6 +253,9 @@ def _run_cv_fold(
         log_callback(f"Processing Fold {fold_idx + 1}/{n_folds}...")
 
     X_train_fold, X_val_fold, y_train_fold, y_val_fold = _slice_fold_data(X, y, train_idx, val_idx)
+    X_train_fold, y_train_fold, X_val_fold, y_val_fold = _apply_fold_preprocessing(
+        preprocessing, X_train_fold, y_train_fold, X_val_fold, y_val_fold
+    )
 
     # Fit
     model_artifact = calculator.fit(X_train_fold, y_train_fold, config)
@@ -457,6 +487,7 @@ def _run_inner_cv(
     random_state: int,
     logger: Any,
     log_callback: Callable[[str], None] | None,
+    preprocessing: "FoldPreprocessor | None" = None,
 ) -> float:
     """Run the inner CV diagnostic loop and return the mean inner score (NaN if none valid).
 
@@ -476,6 +507,9 @@ def _run_inner_cv(
         X_inner_val = _slice_by_index(X_train_fold, inner_val_idx)
         y_inner_train = _slice_by_index(y_train_fold, inner_train_idx)
         y_inner_val = _slice_by_index(y_train_fold, inner_val_idx)
+        X_inner_train, y_inner_train, X_inner_val, y_inner_val = _apply_fold_preprocessing(
+            preprocessing, X_inner_train, y_inner_train, X_inner_val, y_inner_val
+        )
 
         try:
             inner_artifact = calculator.fit(X_inner_train, y_inner_train, config)
@@ -508,8 +542,12 @@ def _evaluate_outer_fold(
     fold_idx: int,
     inner_mean: float,
     log_callback: Callable[[str], None] | None,
+    preprocessing: "FoldPreprocessor | None" = None,
 ) -> dict[str, Any]:
     """Fit on the outer training fold, evaluate on the outer validation fold, and log."""
+    X_train_fold, y_train_fold, X_val_fold, y_val_fold = _apply_fold_preprocessing(
+        preprocessing, X_train_fold, y_train_fold, X_val_fold, y_val_fold
+    )
     model_artifact = calculator.fit(X_train_fold, y_train_fold, config)
     metrics = _score_metrics_for_problem(model_artifact, X_val_fold, y_val_fold, problem_type)
 
@@ -540,6 +578,7 @@ def _perform_nested_cv(
     random_state: int = 42,
     progress_callback: Callable[[int, int], None] | None = None,
     log_callback: Callable[[str], None] | None = None,
+    preprocessing: "FoldPreprocessor | None" = None,
 ) -> dict[str, Any]:
     """
     Performs nested cross-validation with an outer loop for generalization
@@ -595,6 +634,7 @@ def _perform_nested_cv(
             random_state,
             logger,
             log_callback,
+            preprocessing,
         )
 
         # --- Outer evaluation: train on full outer train, evaluate on outer val ---
@@ -610,6 +650,7 @@ def _perform_nested_cv(
                 fold_idx,
                 inner_mean,
                 log_callback,
+                preprocessing,
             )
         )
 

--- a/skyulf-core/skyulf/modeling/fold_preprocessing.py
+++ b/skyulf-core/skyulf/modeling/fold_preprocessing.py
@@ -1,0 +1,33 @@
+"""Per-fold preprocessing refit contract (F-15).
+
+Cross-validation and hyperparameter tuning re-fit only the *model* per fold
+today; any preprocessing fitted upstream on the full training split leaks
+held-out rows into the fitted statistics. Callers that can re-run their
+preprocessing per fold pass an object satisfying :class:`FoldPreprocessor`
+to ``perform_cross_validation`` / the tuning engine, and CV fits it on each
+fold's training rows only before scoring on the held-out rows.
+"""
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class FoldPreprocessor(Protocol):
+    """Structural contract for per-fold preprocessing.
+
+    Implementations must be re-fittable: ``fit_transform`` may be called
+    repeatedly (once per fold), and each call must discard any state from
+    the previous fold. ``transform`` applies the artifacts learned by the
+    most recent ``fit_transform`` to held-out rows without learning from
+    them. ``y`` is passed alongside ``X`` because target-aware steps
+    (target encoders, label encoders fitted on the target, resampling)
+    need it at fit time and may transform it at apply time.
+    """
+
+    def fit_transform(self, X: Any, y: Any) -> tuple[Any, Any]:
+        """Fit on this fold's training rows only; return transformed (X, y)."""
+        ...
+
+    def transform(self, X: Any, y: Any) -> tuple[Any, Any]:
+        """Apply the fitted artifacts to held-out rows without refitting."""
+        ...

--- a/skyulf-core/skyulf/preprocessing/__init__.py
+++ b/skyulf-core/skyulf/preprocessing/__init__.py
@@ -53,6 +53,7 @@ from .feature_selection import (
     VarianceThresholdApplier,
     VarianceThresholdCalculator,
 )
+from .fold_adapter import FeatureEngineerFoldAdapter
 from .geo import (
     GeoDistanceApplier,
     GeoDistanceCalculator,
@@ -136,6 +137,7 @@ __all__ = [
     "SchemaMismatchError",
     "validate_schema",
     "FeatureEngineer",
+    "FeatureEngineerFoldAdapter",
     "SplitCalculator",
     "SplitApplier",
     "TextCleaningCalculator",

--- a/skyulf-core/skyulf/preprocessing/fold_adapter.py
+++ b/skyulf-core/skyulf/preprocessing/fold_adapter.py
@@ -1,0 +1,61 @@
+"""Adapter exposing ``FeatureEngineer`` as a :class:`FoldPreprocessor` (F-15).
+
+Cloning is free here by construction: ``FeatureEngineer`` rebuilds every
+step's calculator/applier fresh from ``steps_config`` via the node registry
+on each ``fit_transform``, so constructing a new engineer per fold *is* the
+clone operation — no fitted state is ever copied or reset.
+"""
+
+from typing import Any
+
+from ..registry import NodeRegistry
+from .pipeline import FeatureEngineer
+
+# Splitter steps already ran upstream of the CV/tuning boundary; re-running
+# them inside a fold would re-split the fold itself.
+SPLITTER_STEP_TYPES = frozenset({"TrainTestSplitter", "Split", "feature_target_split"})
+
+
+class FeatureEngineerFoldAdapter:
+    """Re-runs a preprocessing step chain inside each CV/tuning fold.
+
+    Args:
+        steps_config: The upstream Feature-Engineering node's step list
+            (plain dicts, validated by ``validate_preprocessing_steps``).
+            Splitter steps are filtered out automatically.
+        target_column: Name of the target, kept to reject payloads where X
+            still embeds it — target-aware steps (target encoders, resampling,
+            label encoding of the target) receive ``y`` through the ``(X, y)``
+            payload the same way they do downstream of a real splitter.
+    """
+
+    def __init__(self, steps_config: list[dict[str, Any]], target_column: str):
+        self._steps_config = [
+            step for step in steps_config if step.get("transformer") not in SPLITTER_STEP_TYPES
+        ]
+        self._target_column = target_column
+        # Validate eagerly (unknown transformer names, bad params) so a
+        # misconfigured chain fails at construction, not mid-fold.
+        # validate_preprocessing_steps does not check registry membership,
+        # so resolve each step's calculator explicitly.
+        FeatureEngineer(self._steps_config)
+        for step in self._steps_config:
+            NodeRegistry.get_calculator(step["transformer"])
+        self._engineer: FeatureEngineer | None = None
+
+    def fit_transform(self, X: Any, y: Any) -> tuple[Any, Any]:
+        self._validate_payload(X)
+        engineer = FeatureEngineer(self._steps_config)
+        transformed, _metrics = engineer.fit_transform((X, y))
+        self._engineer = engineer
+        return transformed
+
+    def transform(self, X: Any, y: Any) -> tuple[Any, Any]:
+        if self._engineer is None:
+            raise RuntimeError("transform() called before fit_transform()")
+        self._validate_payload(X)
+        return self._engineer.transform((X, y))
+
+    def _validate_payload(self, X: Any) -> None:
+        if hasattr(X, "columns") and self._target_column in X.columns:
+            raise ValueError(f"target column '{self._target_column}' already present in X")

--- a/skyulf-core/skyulf/preprocessing/fold_adapter.py
+++ b/skyulf-core/skyulf/preprocessing/fold_adapter.py
@@ -54,7 +54,17 @@ class FeatureEngineerFoldAdapter:
         if self._engineer is None:
             raise RuntimeError("transform() called before fit_transform()")
         self._validate_payload(X)
-        return self._engineer.transform((X, y))
+        # At transform/inference time no step needs the target (target-aware
+        # encoders use their fitted artifact; splitters/resampling are skipped).
+        # Feed a bare frame when y is absent — a ``(X, None)`` tuple would trip
+        # ``pack_pipeline_output``'s tuple-shape-lost diagnostic on every step.
+        payload = (X, y) if y is not None else X
+        transformed = self._engineer.transform(payload)
+        # Some appliers return a bare frame instead of the ``(X, y)`` payload;
+        # re-pair so callers always get the FoldPreprocessor protocol shape.
+        if not (isinstance(transformed, tuple) and len(transformed) == 2):
+            transformed = (transformed, y)
+        return transformed
 
     def _validate_payload(self, X: Any) -> None:
         if hasattr(X, "columns") and self._target_column in X.columns:

--- a/skyulf-core/skyulf/preprocessing/fold_adapter.py
+++ b/skyulf-core/skyulf/preprocessing/fold_adapter.py
@@ -15,6 +15,15 @@ from .pipeline import FeatureEngineer
 # them inside a fold would re-split the fold itself.
 SPLITTER_STEP_TYPES = frozenset({"TrainTestSplitter", "Split", "feature_target_split"})
 
+# Steps whose fit_transform changes the row count or the target itself.
+# They cannot run inside an sklearn Pipeline step (transformers may only
+# return X, so the model would be fitted on reshaped X against the original,
+# un-aligned y); the tuning engine reads ``changes_row_count`` to skip the
+# Pipeline wrap for such chains.
+ROW_COUNT_CHANGING_STEP_TYPES = frozenset(
+    {"Oversampling", "Undersampling", "DropMissingRows", "Deduplicate"}
+)
+
 
 class FeatureEngineerFoldAdapter:
     """Re-runs a preprocessing step chain inside each CV/tuning fold.
@@ -34,6 +43,12 @@ class FeatureEngineerFoldAdapter:
             step for step in steps_config if step.get("transformer") not in SPLITTER_STEP_TYPES
         ]
         self._target_column = target_column
+        # True when any step reshapes the rows/target (resampling, row drops):
+        # such chains cannot be wrapped in an sklearn Pipeline step because a
+        # transformer can only hand X to the next step, leaving y un-aligned.
+        self.changes_row_count = any(
+            step.get("transformer") in ROW_COUNT_CHANGING_STEP_TYPES for step in self._steps_config
+        )
         # Validate eagerly (unknown transformer names, bad params) so a
         # misconfigured chain fails at construction, not mid-fold.
         # validate_preprocessing_steps does not check registry membership,

--- a/skyulf-core/skyulf/preprocessing/pipeline.py
+++ b/skyulf-core/skyulf/preprocessing/pipeline.py
@@ -56,7 +56,7 @@ class FeatureEngineer:
         self.steps_config = steps_config
         self.fitted_steps: list[dict[str, Any]] = []
 
-    def transform(self, data: pd.DataFrame | SkyulfDataFrame) -> pd.DataFrame | SkyulfDataFrame:
+    def transform(self, data: pd.DataFrame | SkyulfDataFrame | Any) -> Any:
         """
         Apply fitted transformations to new data.
         """

--- a/skyulf-core/tests/integration/test_cv_per_fold_refit.py
+++ b/skyulf-core/tests/integration/test_cv_per_fold_refit.py
@@ -1,0 +1,197 @@
+"""F-15: per-fold preprocessing refit in cross-validation.
+
+Preprocessing fitted once on the full training split leaks held-out rows
+into the fitted statistics, biasing every CV score optimistically. The
+``preprocessing`` parameter re-fits a :class:`FoldPreprocessor` inside
+every fold: fit on the fold's training rows only, apply to the held-out
+rows. The app always threads the adapter through; ``None`` means the
+caller already transformed the data before splitting.
+"""
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from sklearn.datasets import make_classification
+
+from skyulf.data.dataset import SplitDataset
+from skyulf.modeling.base import StatefulEstimator
+from skyulf.modeling.classification import (
+    LogisticRegressionApplier,
+    LogisticRegressionCalculator,
+)
+from skyulf.modeling.cross_validation import perform_cross_validation
+from skyulf.modeling.fold_preprocessing import FoldPreprocessor
+from skyulf.preprocessing.fold_adapter import FeatureEngineerFoldAdapter
+
+
+def _make_classification_xy(n: int = 120, seed: int = 0) -> tuple[pd.DataFrame, pd.Series]:
+    """Build a clean numeric classification DataFrame and Series."""
+    X_arr, y_arr = make_classification(
+        n_samples=n, n_features=4, n_informative=3, n_redundant=1, random_state=seed
+    )
+    X = pd.DataFrame(X_arr, columns=pd.Index(["a", "b", "c", "d"]))
+    y = pd.Series(y_arr, name="target")
+    return X, y
+
+
+class RecordingPreprocessor:
+    """Records which rows each fit/transform sees; returns data unchanged."""
+
+    def __init__(self) -> None:
+        self.fit_rows: list[list[int]] = []
+        self.transform_rows: list[list[int]] = []
+
+    def fit_transform(self, X: Any, y: Any) -> tuple[Any, Any]:
+        self.fit_rows.append(list(X.index))
+        return X, y
+
+    def transform(self, X: Any, y: Any) -> tuple[Any, Any]:
+        self.transform_rows.append(list(X.index))
+        return X, y
+
+
+def test_recording_preprocessor_satisfies_protocol() -> None:
+    assert isinstance(RecordingPreprocessor(), FoldPreprocessor)
+
+
+def test_preprocessing_refits_on_fold_train_rows_only() -> None:
+    """One fit_transform + one transform per fold; fit rows exclude held-out rows."""
+    X, y = _make_classification_xy()
+    recorder = RecordingPreprocessor()
+
+    result = perform_cross_validation(
+        LogisticRegressionCalculator(),
+        LogisticRegressionApplier(),
+        X,
+        y,
+        config={},
+        n_folds=3,
+        cv_type="k_fold",
+        preprocessing=recorder,
+    )
+
+    assert len(result["folds"]) == 3
+    assert len(recorder.fit_rows) == 3
+    assert len(recorder.transform_rows) == 3
+    all_rows = set(range(len(X)))
+    for fit_rows, val_rows in zip(recorder.fit_rows, recorder.transform_rows, strict=True):
+        assert set(fit_rows).isdisjoint(val_rows), "fold fit must not see held-out rows"
+        assert set(fit_rows) | set(val_rows) == all_rows
+
+
+def test_nested_cv_refits_preprocessing_per_inner_and_outer_fold() -> None:
+    """Nested CV must refit inside both loops, never on a fold's own held-out rows."""
+    X, y = _make_classification_xy()
+    recorder = RecordingPreprocessor()
+
+    result = perform_cross_validation(
+        LogisticRegressionCalculator(),
+        LogisticRegressionApplier(),
+        X,
+        y,
+        config={},
+        n_folds=3,
+        cv_type="nested_cv",
+        preprocessing=recorder,
+    )
+
+    # 3 outer folds x (2 inner + 1 outer) fits, each paired with a transform.
+    assert len(recorder.fit_rows) == 9
+    assert len(recorder.transform_rows) == 9
+    for fit_rows, val_rows in zip(recorder.fit_rows, recorder.transform_rows, strict=True):
+        assert set(fit_rows).isdisjoint(val_rows)
+
+
+def test_woe_noise_target_refit_cv_stays_near_chance() -> None:
+    """End-to-end leakage proof: refitting WOE per fold kills the noise-target leak.
+
+    With 200 categories over 400 pure-noise rows, a full-fit WOE encoding
+    memorises each row's own label (disc > 0.75). Refitting inside each fold
+    must bring CV's roc_auc back to chance, while the same data pre-encoded
+    with the leaky full-fit artifact stays strongly "predictive".
+    """
+    from skyulf.preprocessing.encoding import WOEEncoderApplier, WOEEncoderCalculator
+
+    rng = np.random.default_rng(42)
+    n, n_categories = 400, 200
+    X = pd.DataFrame({"city": [f"c{v}" for v in rng.integers(0, n_categories, size=n)]})
+    y = pd.Series(rng.integers(0, 2, size=n), name="target")
+    steps: list[dict[str, Any]] = [
+        {
+            "name": "woe_city",
+            "transformer": "WOEEncoder",
+            "params": {"columns": ["city"], "regularization": 0.5},
+        }
+    ]
+
+    def disc(auc: float) -> float:
+        return max(auc, 1.0 - auc)
+
+    # Leaky control: full-fit WOE applied to every row before CV.
+    leaky_params = WOEEncoderCalculator().fit((X, y), steps[0]["params"])
+    X_leaky, _y_leaky = WOEEncoderApplier().apply((X, y), dict(leaky_params))
+    leaky = perform_cross_validation(
+        LogisticRegressionCalculator(),
+        LogisticRegressionApplier(),
+        X_leaky,
+        y,
+        config={},
+        n_folds=5,
+        cv_type="k_fold",
+    )
+    auc_leaky = leaky["aggregated_metrics"]["roc_auc"]["mean"]
+
+    # F-15 fix: the same WOE step, refit inside every fold via the adapter.
+    adapter = FeatureEngineerFoldAdapter(steps, target_column="target")
+    refit = perform_cross_validation(
+        LogisticRegressionCalculator(),
+        LogisticRegressionApplier(),
+        X,
+        y,
+        config={},
+        n_folds=5,
+        cv_type="k_fold",
+        preprocessing=adapter,
+    )
+    auc_refit = refit["aggregated_metrics"]["roc_auc"]["mean"]
+
+    assert disc(auc_leaky) > 0.75, (
+        f"expected the leaky encoding to memorise labels, got {auc_leaky}"
+    )
+    assert disc(auc_refit) < 0.65, f"per-fold refit CV should sit near chance, got {auc_refit}"
+
+
+def test_stateful_estimator_cross_validate_passes_preprocessing_through() -> None:
+    """StatefulEstimator.cross_validate must thread the preprocessor into CV."""
+    X, y = _make_classification_xy()
+    dataset = SplitDataset(train=(X, y), test=(X.iloc[:10], y.iloc[:10]))
+    estimator = StatefulEstimator(
+        calculator=LogisticRegressionCalculator(),
+        applier=LogisticRegressionApplier(),
+        node_id="lr",
+    )
+    recorder = RecordingPreprocessor()
+
+    result = estimator.cross_validate(
+        dataset, "target", config={}, n_folds=3, preprocessing=recorder
+    )
+
+    assert len(result["folds"]) == 3
+    assert len(recorder.fit_rows) == 3
+
+
+def test_no_preprocessing_param_scores_pretransformed_data() -> None:
+    """No preprocessing param: CV scores the caller's data as-is (no hook invoked)."""
+    X, y = _make_classification_xy()
+    result = perform_cross_validation(
+        LogisticRegressionCalculator(),
+        LogisticRegressionApplier(),
+        X,
+        y,
+        config={},
+        n_folds=3,
+        cv_type="k_fold",
+    )
+    assert len(result["folds"]) == 3
+    assert "accuracy" in result["aggregated_metrics"]

--- a/skyulf-core/tests/integration/test_tuning_per_fold_refit.py
+++ b/skyulf-core/tests/integration/test_tuning_per_fold_refit.py
@@ -1,0 +1,174 @@
+"""F-15: per-fold preprocessing refit in the tuning engine.
+
+Tuning's internal CV had the same leak as plain CV: preprocessing was
+fitted once on the full training split, so every candidate score was
+optimistically biased. The ``preprocessing`` hook re-fits inside
+each candidate fold for the ``grid``/``random`` strategies (the custom
+loop). Strategies whose CV runs inside sklearn searchers (halving,
+optuna) are rejected with an explicit diagnostic rather than silently
+reporting leaky scores; the app falls back to pre-transformed scoring
+for those with a logged warning.
+"""
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.datasets import make_classification
+
+from skyulf.modeling._tuning.engine import TuningCalculator
+from skyulf.modeling._tuning.schemas import TuningConfig
+from skyulf.modeling.classification import LogisticRegressionCalculator
+from skyulf.modeling.fold_preprocessing import FoldPreprocessor
+from skyulf.preprocessing.fold_adapter import FeatureEngineerFoldAdapter
+
+
+def _make_classification_xy(n: int = 120, seed: int = 0) -> tuple[pd.DataFrame, pd.Series]:
+    X_arr, y_arr = make_classification(
+        n_samples=n, n_features=4, n_informative=3, n_redundant=1, random_state=seed
+    )
+    return (
+        pd.DataFrame(X_arr, columns=pd.Index(["a", "b", "c", "d"])),
+        pd.Series(y_arr, name="target"),
+    )
+
+
+class RecordingPreprocessor:
+    """Records which rows each fit/transform sees; returns data unchanged."""
+
+    def __init__(self) -> None:
+        self.fit_rows: list[list[int]] = []
+        self.transform_rows: list[list[int]] = []
+
+    def fit_transform(self, X: Any, y: Any) -> tuple[Any, Any]:
+        self.fit_rows.append(list(X.index))
+        return X, y
+
+    def transform(self, X: Any, y: Any) -> tuple[Any, Any]:
+        self.transform_rows.append(list(X.index))
+        return X, y
+
+
+def test_recording_preprocessor_satisfies_protocol() -> None:
+    assert isinstance(RecordingPreprocessor(), FoldPreprocessor)
+
+
+def test_tuning_grid_refits_preprocessing_per_candidate_fold() -> None:
+    """2 candidates x 3 folds = 6 fold-fits, each excluding its held-out rows."""
+    X, y = _make_classification_xy()
+    recorder = RecordingPreprocessor()
+    tuner = TuningCalculator(LogisticRegressionCalculator())
+
+    model, result = tuner.fit(
+        X,
+        y,
+        config=TuningConfig(
+            strategy="grid",
+            metric="accuracy",
+            search_space={"C": [0.1, 1.0]},
+            cv_folds=3,
+        ),
+        preprocessing=recorder,
+    )
+
+    assert result.n_trials == 2
+    assert hasattr(model, "predict")
+    # 2 candidates x 3 folds = 6 fold fit/transform pairs, plus one final
+    # full-split refit fit (the serving artifact) with no paired transform.
+    assert len(recorder.fit_rows) == 7
+    assert len(recorder.transform_rows) == 6
+    all_rows = set(range(len(X)))
+    for fit_rows, val_rows in zip(recorder.fit_rows[:6], recorder.transform_rows, strict=True):
+        assert set(fit_rows).isdisjoint(val_rows), "fold fit must not see held-out rows"
+        assert set(fit_rows) | set(val_rows) == all_rows
+    assert set(recorder.fit_rows[-1]) == all_rows  # final refit sees the full split
+
+
+def test_tuning_woe_noise_target_stays_near_chance() -> None:
+    """Leakage proof for tuning scores: refitting WOE per fold kills the
+    noise-target memorization that inflates the leaky best_score."""
+    rng = np.random.default_rng(42)
+    n, n_categories = 400, 200
+    X = pd.DataFrame({"city": [f"c{v}" for v in rng.integers(0, n_categories, size=n)]})
+    y = pd.Series(rng.integers(0, 2, size=n), name="target")
+    steps: list[dict[str, Any]] = [
+        {
+            "name": "woe_city",
+            "transformer": "WOEEncoder",
+            "params": {"columns": ["city"], "regularization": 0.5},
+        }
+    ]
+    config = TuningConfig(
+        strategy="random",
+        metric="roc_auc",
+        n_trials=1,
+        search_space={"C": [1.0]},
+        cv_folds=5,
+    )
+
+    def disc(auc: float) -> float:
+        return max(auc, 1.0 - auc)
+
+    # Leaky control: full-fit WOE applied to every row before tuning.
+    from skyulf.preprocessing.encoding import WOEEncoderApplier, WOEEncoderCalculator
+
+    leaky_params = WOEEncoderCalculator().fit((X, y), steps[0]["params"])
+    X_leaky, _y_leaky = WOEEncoderApplier().apply((X, y), dict(leaky_params))
+    _model_leaky, leaky_result = TuningCalculator(LogisticRegressionCalculator()).fit(
+        X_leaky, y, config=config
+    )
+
+    # F-15 fix: the same WOE step refit inside every candidate fold.
+    adapter = FeatureEngineerFoldAdapter(steps, target_column="target")
+    _model_refit, refit_result = TuningCalculator(LogisticRegressionCalculator()).fit(
+        X, y, config=config, preprocessing=adapter
+    )
+
+    assert disc(leaky_result.best_score) > 0.75, (
+        f"expected the leaky encoding to memorise labels, got {leaky_result.best_score}"
+    )
+    assert disc(refit_result.best_score) < 0.65, (
+        f"per-fold refit tuning should sit near chance, got {refit_result.best_score}"
+    )
+
+
+def test_halving_strategy_with_preprocessing_is_rejected() -> None:
+    """Halving searchers run CV inside sklearn; the hook cannot reach those
+    folds, so refuse loudly instead of silently reporting leaky scores."""
+    X, y = _make_classification_xy()
+    tuner = TuningCalculator(LogisticRegressionCalculator())
+    with pytest.raises(ValueError, match="Per-fold"):
+        tuner.fit(
+            X,
+            y,
+            config=TuningConfig(strategy="halving_grid", search_space={"C": [1.0]}),
+            preprocessing=RecordingPreprocessor(),
+        )
+
+
+def test_optuna_strategy_with_preprocessing_is_rejected() -> None:
+    """Same refusal for the optuna strategy — before any optuna machinery."""
+    X, y = _make_classification_xy()
+    tuner = TuningCalculator(LogisticRegressionCalculator())
+    with pytest.raises(ValueError, match="Per-fold"):
+        tuner.fit(
+            X,
+            y,
+            config=TuningConfig(strategy="optuna", search_space={"C": [1.0]}),
+            preprocessing=RecordingPreprocessor(),
+        )
+
+
+def test_validation_data_with_preprocessing_is_rejected() -> None:
+    """Holdout (PredefinedSplit) tuning cannot be re-run fold-wise in v1."""
+    X, y = _make_classification_xy()
+    tuner = TuningCalculator(LogisticRegressionCalculator())
+    with pytest.raises(ValueError, match="validation"):
+        tuner.fit(
+            X,
+            y,
+            config=TuningConfig(strategy="grid", search_space={"C": [1.0]}),
+            validation_data=(X.iloc[:20], y.iloc[:20]),
+            preprocessing=RecordingPreprocessor(),
+        )

--- a/skyulf-core/tests/integration/test_tuning_per_fold_refit.py
+++ b/skyulf-core/tests/integration/test_tuning_per_fold_refit.py
@@ -2,12 +2,12 @@
 
 Tuning's internal CV had the same leak as plain CV: preprocessing was
 fitted once on the full training split, so every candidate score was
-optimistically biased. The ``preprocessing`` hook re-fits inside
-each candidate fold for the ``grid``/``random`` strategies (the custom
-loop). Strategies whose CV runs inside sklearn searchers (halving,
-optuna) are rejected with an explicit diagnostic rather than silently
-reporting leaky scores; the app falls back to pre-transformed scoring
-for those with a logged warning.
+optimistically biased. The ``preprocessing`` hook re-fits inside each
+candidate fold: for ``grid``/``random`` via the engine's own fold loop,
+and for ``halving_*``/``optuna`` by wrapping preprocessing + model in an
+sklearn ``Pipeline`` so the searcher's internal CV refits per fold.
+Holdout tuning with ``validation_data`` is rejected with an explicit
+diagnostic — there are no folds to refit around.
 """
 
 from typing import Any
@@ -133,31 +133,157 @@ def test_tuning_woe_noise_target_stays_near_chance() -> None:
     )
 
 
-def test_halving_strategy_with_preprocessing_is_rejected() -> None:
-    """Halving searchers run CV inside sklearn; the hook cannot reach those
-    folds, so refuse loudly instead of silently reporting leaky scores."""
-    X, y = _make_classification_xy()
-    tuner = TuningCalculator(LogisticRegressionCalculator())
-    with pytest.raises(ValueError, match="Per-fold"):
-        tuner.fit(
-            X,
-            y,
-            config=TuningConfig(strategy="halving_grid", search_space={"C": [1.0]}),
-            preprocessing=RecordingPreprocessor(),
-        )
+def _noise_woe_setup() -> tuple[pd.DataFrame, pd.Series, list[dict[str, Any]]]:
+    """Pure-noise target + memorising WOE step (shared leakage probe)."""
+    rng = np.random.default_rng(42)
+    n, n_categories = 400, 200
+    X = pd.DataFrame({"city": [f"c{v}" for v in rng.integers(0, n_categories, size=n)]})
+    y = pd.Series(rng.integers(0, 2, size=n), name="target")
+    steps: list[dict[str, Any]] = [
+        {
+            "name": "woe_city",
+            "transformer": "WOEEncoder",
+            "params": {"columns": ["city"], "regularization": 0.5},
+        }
+    ]
+    return X, y, steps
 
 
-def test_optuna_strategy_with_preprocessing_is_rejected() -> None:
-    """Same refusal for the optuna strategy — before any optuna machinery."""
+def _disc(auc: float) -> float:
+    return max(auc, 1.0 - auc)
+
+
+def test_tuning_halving_grid_refits_woe_noise_near_chance() -> None:
+    """halving_grid runs its CV inside the sklearn searcher; the Pipeline
+    wrapper must refit WOE per fold there too, killing the noise-target leak."""
+    from skyulf.preprocessing.encoding import WOEEncoderApplier, WOEEncoderCalculator
+
+    X, y, steps = _noise_woe_setup()
+    config = TuningConfig(
+        strategy="halving_grid", metric="roc_auc", search_space={"C": [1.0]}, cv_folds=5
+    )
+
+    leaky_params = WOEEncoderCalculator().fit((X, y), steps[0]["params"])
+    X_leaky, _ = WOEEncoderApplier().apply((X, y), dict(leaky_params))
+    _m, leaky_result = TuningCalculator(LogisticRegressionCalculator()).fit(
+        X_leaky, y, config=config
+    )
+
+    adapter = FeatureEngineerFoldAdapter(steps, target_column="target")
+    _m, refit_result = TuningCalculator(LogisticRegressionCalculator()).fit(
+        X, y, config=config, preprocessing=adapter
+    )
+
+    assert _disc(leaky_result.best_score) > 0.75, (
+        f"expected the leaky encoding to memorise labels, got {leaky_result.best_score}"
+    )
+    assert _disc(refit_result.best_score) < 0.65, (
+        f"per-fold refit halving tuning should sit near chance, got {refit_result.best_score}"
+    )
+    assert refit_result.best_params == {"C": 1.0}, (
+        "Pipeline param prefixes must be stripped from best_params"
+    )
+
+
+def test_tuning_optuna_refits_woe_noise_near_chance() -> None:
+    """Same honesty proof for the optuna strategy's searcher-internal CV."""
+    from skyulf.preprocessing.encoding import WOEEncoderApplier, WOEEncoderCalculator
+
+    X, y, steps = _noise_woe_setup()
+    config = TuningConfig(
+        strategy="optuna", metric="roc_auc", n_trials=2, search_space={"C": [1.0]}, cv_folds=5
+    )
+
+    leaky_params = WOEEncoderCalculator().fit((X, y), steps[0]["params"])
+    X_leaky, _ = WOEEncoderApplier().apply((X, y), dict(leaky_params))
+    _m, leaky_result = TuningCalculator(LogisticRegressionCalculator()).fit(
+        X_leaky, y, config=config
+    )
+
+    adapter = FeatureEngineerFoldAdapter(steps, target_column="target")
+    _m, refit_result = TuningCalculator(LogisticRegressionCalculator()).fit(
+        X, y, config=config, preprocessing=adapter
+    )
+
+    assert _disc(leaky_result.best_score) > 0.75, (
+        f"expected the leaky encoding to memorise labels, got {leaky_result.best_score}"
+    )
+    assert _disc(refit_result.best_score) < 0.65, (
+        f"per-fold refit optuna tuning should sit near chance, got {refit_result.best_score}"
+    )
+    assert refit_result.best_params == {"C": 1.0}
+
+
+def test_tuning_halving_random_refits_woe_noise_near_chance() -> None:
+    """The halving_random variant gets the same honesty proof as halving_grid."""
+    from skyulf.preprocessing.encoding import WOEEncoderApplier, WOEEncoderCalculator
+
+    X, y, steps = _noise_woe_setup()
+    config = TuningConfig(
+        strategy="halving_random", metric="roc_auc", search_space={"C": [1.0]}, cv_folds=5
+    )
+
+    leaky_params = WOEEncoderCalculator().fit((X, y), steps[0]["params"])
+    X_leaky, _ = WOEEncoderApplier().apply((X, y), dict(leaky_params))
+    _m, leaky_result = TuningCalculator(LogisticRegressionCalculator()).fit(
+        X_leaky, y, config=config
+    )
+
+    adapter = FeatureEngineerFoldAdapter(steps, target_column="target")
+    _m, refit_result = TuningCalculator(LogisticRegressionCalculator()).fit(
+        X, y, config=config, preprocessing=adapter
+    )
+
+    assert _disc(leaky_result.best_score) > 0.75
+    assert _disc(refit_result.best_score) < 0.65, (
+        f"per-fold refit halving_random tuning should sit near chance, "
+        f"got {refit_result.best_score}"
+    )
+
+
+def test_halving_multi_candidate_results_carry_unprefixed_params() -> None:
+    """Several candidates exercise successive-halving iterations; extracted
+    best_params and per-trial params must keep the caller's original keys."""
     X, y = _make_classification_xy()
-    tuner = TuningCalculator(LogisticRegressionCalculator())
-    with pytest.raises(ValueError, match="Per-fold"):
-        tuner.fit(
-            X,
-            y,
-            config=TuningConfig(strategy="optuna", search_space={"C": [1.0]}),
-            preprocessing=RecordingPreprocessor(),
-        )
+    config = TuningConfig(
+        strategy="halving_grid",
+        metric="accuracy",
+        search_space={"C": [0.1, 1.0, 10.0]},
+        cv_folds=3,
+    )
+
+    _model, result = TuningCalculator(LogisticRegressionCalculator()).fit(
+        X, y, config=config, preprocessing=RecordingPreprocessor()
+    )
+
+    assert set(result.best_params) == {"C"}, result.best_params
+    assert result.trials, "halving must report at least one trial"
+    for trial in result.trials:
+        assert set(trial["params"]) == {"C"}, trial["params"]
+
+
+def test_halving_grid_refits_on_fold_train_rows_only() -> None:
+    """Fold isolation inside the halving searcher: every refit sees only its
+    fold's training rows, never the rows it is scored against."""
+    X, y = _make_classification_xy()
+    recorder = RecordingPreprocessor()
+
+    TuningCalculator(LogisticRegressionCalculator()).fit(
+        X,
+        y,
+        config=TuningConfig(strategy="halving_grid", search_space={"C": [1.0]}, cv_folds=3),
+        preprocessing=recorder,
+    )
+
+    assert recorder.fit_rows, "the searcher's internal CV must trigger per-fold refits"
+    all_rows = set(range(len(X)))
+    # One extra fit with no paired transform: the final best-model refit on
+    # the full split (the serving artifact).
+    assert len(recorder.fit_rows) == len(recorder.transform_rows) + 1
+    for fit_rows, val_rows in zip(recorder.fit_rows[:-1], recorder.transform_rows, strict=True):
+        assert set(fit_rows).isdisjoint(val_rows), "fold fit must not see held-out rows"
+        assert set(fit_rows) | set(val_rows) <= all_rows
+    assert set(recorder.fit_rows[-1]) == all_rows
 
 
 def test_validation_data_with_preprocessing_is_rejected() -> None:

--- a/skyulf-core/tests/unit/test_fold_pipeline.py
+++ b/skyulf-core/tests/unit/test_fold_pipeline.py
@@ -1,0 +1,97 @@
+"""Unit tests for ``FoldPreprocessingStep`` — the Pipeline step that gives
+``halving_*``/``optuna`` tuning their per-fold refit (F-15 follow-up)."""
+
+from typing import Any
+
+import pandas as pd
+from sklearn.base import clone
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import GridSearchCV
+from sklearn.pipeline import Pipeline
+
+from skyulf.modeling._tuning.fold_pipeline import FoldPreprocessingStep
+
+
+class RowDroppingPreprocessor:
+    """fit_transform drops the first row; transform keeps every row (F-18)."""
+
+    def fit_transform(self, X: Any, y: Any) -> tuple[Any, Any]:
+        return X.iloc[1:], y.iloc[1:]
+
+    def transform(self, X: Any, y: Any) -> tuple[Any, Any]:
+        return X, y
+
+
+class CountingPreprocessor:
+    """Counts fit_transform calls; deep-copy isolation probe."""
+
+    def __init__(self) -> None:
+        self.fits = 0
+
+    def fit_transform(self, X: Any, y: Any) -> tuple[Any, Any]:
+        self.fits += 1
+        return X, y
+
+    def transform(self, X: Any, y: Any) -> tuple[Any, Any]:
+        return X, y
+
+
+def _xy() -> tuple[pd.DataFrame, pd.Series]:
+    X = pd.DataFrame({"a": range(20), "b": range(20, 40)})
+    y = pd.Series([0, 1] * 10, name="target")
+    return X, y
+
+
+def test_fit_transform_returns_refit_output_directly() -> None:
+    """Row-count-changing steps shape what the model trains on, while
+    transform keeps every held-out row."""
+    X, y = _xy()
+    step = FoldPreprocessingStep(RowDroppingPreprocessor())
+
+    trained_on = step.fit_transform(X, y)
+    assert len(trained_on) == len(X) - 1
+
+    held_out = step.transform(X)
+    assert len(held_out) == len(X)
+
+
+def test_fit_deep_copies_the_preprocessor() -> None:
+    """Searcher clones share one constructor preprocessor; each fit must work
+    on its own copy so parallel candidates never share fitted state."""
+    X, y = _xy()
+    original = CountingPreprocessor()
+    step = FoldPreprocessingStep(original)
+
+    step.fit(X, y)
+    assert original.fits == 0  # the worker was a deep copy
+    assert step.preprocessor_.fits == 1
+
+    step.fit(X, y)  # second fit starts from a fresh copy again
+    assert original.fits == 0
+    assert step.preprocessor_.fits == 1
+
+
+def test_step_is_sklearn_cloneable() -> None:
+    step = FoldPreprocessingStep(CountingPreprocessor())
+    cloned = clone(step)
+    assert cloned is not step
+    assert isinstance(cloned, FoldPreprocessingStep)
+
+
+def test_searcher_cv_refits_every_fold_and_leaves_original_unfitted() -> None:
+    """Inside a real searcher's CV loop: one worker fit per fold, the shared
+    constructor preprocessor never fitted."""
+    X, y = _xy()
+    original = CountingPreprocessor()
+    pipe = Pipeline(
+        [
+            ("preprocessing", FoldPreprocessingStep(original)),
+            ("model", LogisticRegression()),
+        ]
+    )
+
+    search = GridSearchCV(pipe, {"model__C": [1.0]}, cv=3)
+    search.fit(X, y)
+
+    assert original.fits == 0
+    assert search.best_params_ == {"model__C": 1.0}

--- a/skyulf-core/tests/unit/test_fold_preprocessing.py
+++ b/skyulf-core/tests/unit/test_fold_preprocessing.py
@@ -23,16 +23,15 @@ def _frame(engine: str, with_outlier: bool = False) -> tuple:
     statistics must NOT reflect the held-out tail (where the outlier lives).
     """
     n = 40
-    values = [float(i) for i in range(n)]
+    values: list[float | None] = [float(i) for i in range(n)]
     values[5] = None  # missing value for the imputer to learn a fill for
     if with_outlier:
         values[-1] = 10000.0  # only present in the held-out portion
-    df = pd.DataFrame({"x": values, "target": [i % 2 for i in range(n)]})
+    pdf = pd.DataFrame({"x": values, "target": [i % 2 for i in range(n)]})
     if engine == "polars":
-        df = pl.from_pandas(df)
-    X = df.drop("target", axis=1) if engine == "pandas" else df.drop("target")
-    y = df["target"]
-    return X, y
+        df = pl.from_pandas(pdf)
+        return df.drop("target"), df["target"]
+    return pdf.drop("target", axis=1), pdf["target"]
 
 
 def _split(engine: str, X, y, n_train: int = 30):

--- a/skyulf-core/tests/unit/test_fold_preprocessing.py
+++ b/skyulf-core/tests/unit/test_fold_preprocessing.py
@@ -172,3 +172,23 @@ def test_adapter_reports_row_alignment_for_shape_preserving_steps():
         target_column="target",
     )
     assert adapter.changes_row_count is False
+
+
+def test_adapter_transform_before_fit_raises():
+    adapter = FeatureEngineerFoldAdapter(
+        steps_config=[{"name": "s", "transformer": "StandardScaler", "params": {}}],
+        target_column="target",
+    )
+    X, y = _frame("pandas")
+    with pytest.raises(RuntimeError, match="before fit_transform"):
+        adapter.transform(X, y)
+
+
+def test_adapter_rejects_payload_still_carrying_the_target():
+    adapter = FeatureEngineerFoldAdapter(
+        steps_config=[{"name": "s", "transformer": "StandardScaler", "params": {}}],
+        target_column="target",
+    )
+    pdf = pd.DataFrame({"x": [1.0, 2.0], "target": [0, 1]})
+    with pytest.raises(ValueError, match="already present in X"):
+        adapter.fit_transform(pdf, pdf["target"])

--- a/skyulf-core/tests/unit/test_fold_preprocessing.py
+++ b/skyulf-core/tests/unit/test_fold_preprocessing.py
@@ -1,0 +1,156 @@
+"""Tests for the per-fold preprocessing refit contract (F-15 design note).
+
+`FoldPreprocessor` is the engine-agnostic contract CV/tuning use to re-fit
+preprocessing inside each fold; `FeatureEngineerFoldAdapter` implements it on
+top of `FeatureEngineer` by rebuilding a fresh pipeline from `steps_config`
+per fit (the registry constructs fresh calculators, so reconstruction *is*
+the clone operation).
+"""
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import pytest
+
+from skyulf.modeling import FoldPreprocessor
+from skyulf.preprocessing import FeatureEngineerFoldAdapter
+
+
+def _frame(engine: str, with_outlier: bool = False) -> tuple:
+    """40-row frame: a float column with one null, an id-like column, target.
+
+    The train fold used in tests excludes the last 10 rows, so per-fold fit
+    statistics must NOT reflect the held-out tail (where the outlier lives).
+    """
+    n = 40
+    values = [float(i) for i in range(n)]
+    values[5] = None  # missing value for the imputer to learn a fill for
+    if with_outlier:
+        values[-1] = 10000.0  # only present in the held-out portion
+    df = pd.DataFrame({"x": values, "target": [i % 2 for i in range(n)]})
+    if engine == "polars":
+        df = pl.from_pandas(df)
+    X = df.drop("target", axis=1) if engine == "pandas" else df.drop("target")
+    y = df["target"]
+    return X, y
+
+
+def _split(engine: str, X, y, n_train: int = 30):
+    if engine == "pandas":
+        return X.iloc[:n_train], X.iloc[n_train:], y.iloc[:n_train], y.iloc[n_train:]
+    return X[:n_train], X[n_train:], y[:n_train], y[n_train:]
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+def test_adapter_imputer_statistics_come_from_the_fit_fold_only(engine: str):
+    X, y = _frame(engine)
+    X_tr, X_val, y_tr, y_val = _split(engine, X, y)
+
+    adapter = FeatureEngineerFoldAdapter(
+        steps_config=[
+            {
+                "name": "fill",
+                "transformer": "SimpleImputer",
+                "params": {"strategy": "mean"},
+            },
+        ],
+        target_column="target",
+    )
+    X_tr_t, y_tr_t = adapter.fit_transform(X_tr, y_tr)
+
+    # Mean of x over the train fold excluding the null: mean(0..29 minus 5)
+    expected_fill = float(np.mean([float(i) for i in range(30) if i != 5]))
+    to_pandas = getattr(X_tr_t, "to_pandas", None)
+    fitted = to_pandas() if callable(to_pandas) else X_tr_t
+    assert not fitted["x"].isna().any()
+    assert fitted.loc[5, "x"] == pytest.approx(expected_fill)
+
+    # transform must reuse the fitted fill value, ignoring held-out rows
+    X_val_t, y_val_t = adapter.transform(X_val, y_val)
+    to_pandas = getattr(X_val_t, "to_pandas", None)
+    applied = to_pandas() if callable(to_pandas) else X_val_t
+    assert applied["x"].notna().all()
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+def test_adapter_rebuilds_fresh_state_per_fit(engine: str):
+    """A second fit_transform on different rows must not inherit statistics
+    from the first — reconstruction from steps_config is the clone."""
+    X, y = _frame(engine)
+    X_tr, X_val, y_tr, y_val = _split(engine, X, y)
+
+    adapter = FeatureEngineerFoldAdapter(
+        steps_config=[
+            {"name": "fill", "transformer": "SimpleImputer", "params": {"strategy": "mean"}},
+        ],
+        target_column="target",
+    )
+    adapter.fit_transform(X_tr, y_tr)
+
+    # Fit on just 5 rows: the learned mean is now the mean of those rows.
+    small_X = X_tr.iloc[:5] if engine == "pandas" else X_tr[:5]
+    small_y = y_tr.iloc[:5] if engine == "pandas" else y_tr[:5]
+    adapter.fit_transform(small_X, small_y)
+    X_val_t, _ = adapter.transform(X_val, y_val)
+    to_pandas = getattr(X_val_t, "to_pandas", None)
+    applied = to_pandas() if callable(to_pandas) else X_val_t
+    # Held-out values below/above the small-fold mean must NOT be clipped to
+    # the old 30-row statistics — they are scaled by the new fold's scaler.
+    assert applied["x"].notna().all()
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+def test_adapter_filters_out_splitter_steps(engine: str):
+    """Splitter steps already ran upstream; re-executing them inside a fold
+    would re-split the fold. The adapter must drop them from the chain."""
+    X, y = _frame(engine)
+    X_tr, X_val, y_tr, y_val = _split(engine, X, y)
+
+    adapter = FeatureEngineerFoldAdapter(
+        steps_config=[
+            {"name": "split", "transformer": "TrainTestSplitter", "params": {"test_size": 0.2}},
+            {"name": "fill", "transformer": "SimpleImputer", "params": {"strategy": "mean"}},
+        ],
+        target_column="target",
+    )
+    X_tr_t, y_tr_t = adapter.fit_transform(X_tr, y_tr)
+    # Output stays an (X, y) frame pair — no SplitDataset appeared.
+    to_pandas = getattr(X_tr_t, "to_pandas", None)
+    fitted = to_pandas() if callable(to_pandas) else X_tr_t
+    assert "x" in fitted.columns
+    assert len(fitted) == len(X_tr_t) and len(fitted) <= len(X_tr)
+
+
+@pytest.mark.parametrize("engine", ["pandas", "polars"])
+def test_adapter_transform_keeps_all_held_out_rows(engine: str):
+    """Row-dropping steps are train-only (F-18 discipline): transform must
+    never delete held-out rows."""
+    X, y = _frame(engine)
+    X_tr, X_val, y_tr, y_val = _split(engine, X, y)
+
+    adapter = FeatureEngineerFoldAdapter(
+        steps_config=[
+            {"name": "dedup", "transformer": "Deduplicate", "params": {}},
+            {"name": "fill", "transformer": "SimpleImputer", "params": {"strategy": "mean"}},
+        ],
+        target_column="target",
+    )
+    adapter.fit_transform(X_tr, y_tr)
+    X_val_t, y_val_t = adapter.transform(X_val, y_val)
+    n_val = len(X_val) if not hasattr(X_val, "shape") else X_val.shape[0]
+    to_pandas = getattr(X_val_t, "to_pandas", None)
+    applied = to_pandas() if callable(to_pandas) else X_val_t
+    assert applied.shape[0] == n_val
+
+
+def test_adapter_satisfies_the_fold_preprocessor_protocol():
+    adapter = FeatureEngineerFoldAdapter(steps_config=[], target_column="target")
+    assert isinstance(adapter, FoldPreprocessor)
+
+
+def test_adapter_rejects_unknown_transformer():
+    with pytest.raises(ValueError):
+        FeatureEngineerFoldAdapter(
+            steps_config=[{"name": "x", "transformer": "NoSuchNode", "params": {}}],
+            target_column="target",
+        )

--- a/skyulf-core/tests/unit/test_fold_preprocessing.py
+++ b/skyulf-core/tests/unit/test_fold_preprocessing.py
@@ -153,3 +153,22 @@ def test_adapter_rejects_unknown_transformer():
             steps_config=[{"name": "x", "transformer": "NoSuchNode", "params": {}}],
             target_column="target",
         )
+
+
+@pytest.mark.parametrize(
+    "transformer", ["Oversampling", "Undersampling", "DropMissingRows", "Deduplicate"]
+)
+def test_adapter_flags_row_count_changing_steps(transformer: str):
+    adapter = FeatureEngineerFoldAdapter(
+        steps_config=[{"name": "s", "transformer": transformer, "params": {}}],
+        target_column="target",
+    )
+    assert adapter.changes_row_count is True
+
+
+def test_adapter_reports_row_alignment_for_shape_preserving_steps():
+    adapter = FeatureEngineerFoldAdapter(
+        steps_config=[{"name": "s", "transformer": "StandardScaler", "params": {}}],
+        target_column="target",
+    )
+    assert adapter.changes_row_count is False

--- a/skyulf-core/tests/unit/test_modeling_base.py
+++ b/skyulf-core/tests/unit/test_modeling_base.py
@@ -325,6 +325,66 @@ def test_fit_predict_regression():
     )
 
 
+def test_fit_predict_preprocessing_without_payload_raises():
+    """fit_predict(preprocessing=...) without preprocessing_train should raise."""
+    dataset, _ = _classification_dataset()
+
+    class _NoopPreprocessor:
+        def fit_transform(self, X, y):
+            return X, y
+
+        def transform(self, X, y):
+            return X, y
+
+    estimator = StatefulEstimator(
+        calculator=_DummyCalculator(), applier=_DummyApplier(), node_id="p1"
+    )
+    with pytest.raises(ValueError, match="preprocessing_train"):
+        estimator.fit_predict(dataset, "target", config={}, preprocessing=_NoopPreprocessor())
+
+
+def test_fit_predict_preprocessing_routes_payload_to_calculator():
+    """fit_predict(preprocessing=...) should fit the calculator on the pre-transform payload."""
+    dataset, df = _classification_dataset()
+    pre_X = df.drop(columns=["target"]).iloc[:160]
+    pre_y = df["target"].iloc[:160]
+
+    class _RecordingCalculator(_DummyCalculator):
+        def __init__(self):
+            self.fit_kwargs: dict[str, Any] = {}
+            self.fit_X_len = 0
+
+        def fit(
+            self,
+            X,
+            y,
+            config,
+            progress_callback=None,
+            log_callback=None,
+            validation_data=None,
+            preprocessing=None,
+        ):
+            self.fit_kwargs = {"validation_data": validation_data, "preprocessing": preprocessing}
+            self.fit_X_len = len(X)
+            assert preprocessing is not None
+            return super().fit(X, y, config, progress_callback, log_callback, validation_data)
+
+    calculator = _RecordingCalculator()
+    estimator = StatefulEstimator(calculator=calculator, applier=_DummyApplier(), node_id="p2")
+    preprocessor = object()
+    preds = estimator.fit_predict(
+        dataset,
+        "target",
+        config={},
+        preprocessing=preprocessor,  # type: ignore[arg-type]
+        preprocessing_train=(pre_X, pre_y),
+    )
+    assert len(preds["train"]) == 160
+    assert len(preds["test"]) == 40
+    assert calculator.fit_X_len == 160
+    assert calculator.fit_kwargs["preprocessing"] is preprocessor
+
+
 # ---------------------------------------------------------------------------
 # StatefulEstimator.evaluate
 # ---------------------------------------------------------------------------

--- a/skyulf-core/tests/unit/test_modeling_base.py
+++ b/skyulf-core/tests/unit/test_modeling_base.py
@@ -371,12 +371,20 @@ def test_fit_predict_preprocessing_routes_payload_to_calculator():
 
     calculator = _RecordingCalculator()
     estimator = StatefulEstimator(calculator=calculator, applier=_DummyApplier(), node_id="p2")
-    preprocessor = object()
+
+    class _PassThroughPreprocessor:
+        def fit_transform(self, X, y):
+            return X, y
+
+        def transform(self, X, y):
+            return X, y
+
+    preprocessor = _PassThroughPreprocessor()
     preds = estimator.fit_predict(
         dataset,
         "target",
         config={},
-        preprocessing=preprocessor,  # type: ignore[arg-type]
+        preprocessing=preprocessor,
         preprocessing_train=(pre_X, pre_y),
     )
     assert len(preds["train"]) == 160

--- a/skyulf-core/tests/unit/test_tuning_engine.py
+++ b/skyulf-core/tests/unit/test_tuning_engine.py
@@ -545,12 +545,15 @@ def test_fit_halving_grid_search():
 
 
 class _StubPreprocessor:
-    """Minimal FoldPreprocessor stub with a configurable alignment flag."""
+    """Minimal FoldPreprocessor stub with configurable flag + fit_transform."""
 
-    def __init__(self, changes_row_count: bool):
+    def __init__(self, changes_row_count: bool, fit_transform=None):
         self.changes_row_count = changes_row_count
+        self._fit_transform = fit_transform
 
     def fit_transform(self, X, y):
+        if self._fit_transform is not None:
+            return self._fit_transform(X, y)
         return X, y
 
     def transform(self, X, y):
@@ -618,6 +621,63 @@ def test_halving_wrap_kept_for_shape_preserving_preprocessing(monkeypatch):
     )
     assert isinstance(estimator, Pipeline)
     assert not any("Per-fold preprocessing refit skipped" in message for message in logs)
+
+
+def test_alignment_probe_refuses_row_dropping_preprocessor(monkeypatch):
+    """The runtime probe catches row drops even when the static flag is False."""
+    estimator, logs, _result = _tune_with_spied_halving_build(
+        monkeypatch,
+        _StubPreprocessor(
+            changes_row_count=False,
+            fit_transform=lambda X, y: (X.iloc[:-1], y.iloc[:-1]),
+        ),
+    )
+    assert not isinstance(estimator, Pipeline)
+    assert any("Per-fold preprocessing refit skipped" in message for message in logs)
+
+
+def test_alignment_probe_refuses_target_mutating_preprocessor(monkeypatch):
+    """A target-only re-encoding keeps rows but changes y values; probe refuses."""
+    estimator, logs, _result = _tune_with_spied_halving_build(
+        monkeypatch,
+        _StubPreprocessor(
+            changes_row_count=False,
+            fit_transform=lambda X, y: (X, y.map({0: "neg", 1: "pos"})),
+        ),
+    )
+    assert not isinstance(estimator, Pipeline)
+    assert any("Per-fold preprocessing refit skipped" in message for message in logs)
+
+
+def test_alignment_probe_fails_closed_when_fit_transform_raises(monkeypatch):
+    def broken(X, y):
+        raise RuntimeError("cannot probe")
+
+    estimator, logs, _result = _tune_with_spied_halving_build(
+        monkeypatch,
+        _StubPreprocessor(changes_row_count=False, fit_transform=broken),
+    )
+    assert not isinstance(estimator, Pipeline)
+    assert any("Per-fold preprocessing refit skipped" in message for message in logs)
+
+
+def test_alignment_probe_without_frames_relies_on_static_flag():
+    X, y = _clf_xy(n=30)
+    frames = (pd.DataFrame(X), pd.Series(y))
+    assert engine_mod._preserves_row_and_target_alignment(
+        _StubPreprocessor(changes_row_count=False), frames
+    )
+    assert not engine_mod._preserves_row_and_target_alignment(
+        _StubPreprocessor(
+            changes_row_count=False,
+            fit_transform=lambda X, y: (X.iloc[:-1], y.iloc[:-1]),
+        ),
+        frames,
+    )
+    # No named frames to probe (numpy-only library call): nothing to check.
+    assert engine_mod._preserves_row_and_target_alignment(
+        _StubPreprocessor(changes_row_count=False), None
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/skyulf-core/tests/unit/test_tuning_engine.py
+++ b/skyulf-core/tests/unit/test_tuning_engine.py
@@ -11,6 +11,7 @@ import polars as pl
 import pytest
 from sklearn.datasets import make_classification, make_regression
 from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
 from tests.utils.test_case_loader import TestCaseLoader
 
 from skyulf.modeling._tuning import engine as engine_mod
@@ -536,6 +537,87 @@ def test_fit_halving_grid_search():
     model, result = tuner.fit(X, y, config=cfg.__dict__)
     assert hasattr(model, "predict")
     assert result.best_score > 0
+
+
+# ---------------------------------------------------------------------------
+# Halving/optuna Pipeline wrap: row-count-changing preprocessing guard
+# ---------------------------------------------------------------------------
+
+
+class _StubPreprocessor:
+    """Minimal FoldPreprocessor stub with a configurable alignment flag."""
+
+    def __init__(self, changes_row_count: bool):
+        self.changes_row_count = changes_row_count
+
+    def fit_transform(self, X, y):
+        return X, y
+
+    def transform(self, X, y):
+        return X, y
+
+
+def _tune_with_spied_halving_build(monkeypatch, preprocessing):
+    """Run halving_grid tune() with the searcher machinery spied/stubbed.
+
+    Returns ``(estimator_passed_to_searcher, logs, result)`` without running a
+    real search.
+    """
+    built: dict[str, Any] = {}
+    logs: list[str] = []
+
+    def fake_build(self, search_config, estimator, cv, metric, log_callback):
+        built["estimator"] = estimator
+        return object()
+
+    monkeypatch.setattr(TuningCalculator, "_build_halving_searcher", fake_build)
+    monkeypatch.setattr(TuningCalculator, "_execute_search", lambda self, *a, **k: None)
+    monkeypatch.setattr(
+        TuningCalculator, "_extract_best_result", lambda self, searcher: ({"C": 1.0}, 0.9)
+    )
+    monkeypatch.setattr(TuningCalculator, "_collect_trials", lambda self, searcher, config: [])
+    monkeypatch.setattr(TuningCalculator, "_log_final_completion", lambda self, *a: None)
+
+    X, y = _clf_xy(n=60)
+    cfg = TuningConfig(
+        strategy="halving_grid",
+        metric="accuracy",
+        search_space={"C": [0.1, 1.0]},
+        cv_folds=3,
+    )
+    result = _tuner_clf().tune(
+        X,
+        y,
+        cfg,
+        log_callback=logs.append,
+        preprocessing=preprocessing,
+        preprocessing_frames=(pd.DataFrame(X), pd.Series(y)),
+    )
+    return built["estimator"], logs, result
+
+
+def test_halving_wrap_refused_for_row_shaping_preprocessing(monkeypatch):
+    """A resampling/row-dropping chain must not enter the searcher Pipeline.
+
+    An sklearn transformer step can only hand X forward, so the model would be
+    fitted on reshaped rows against the original y; the engine skips the wrap
+    and falls back to pre-transformed scoring with an explicit log instead.
+    """
+    estimator, logs, result = _tune_with_spied_halving_build(
+        monkeypatch, _StubPreprocessor(changes_row_count=True)
+    )
+    assert not isinstance(estimator, Pipeline)
+    assert any("Per-fold preprocessing refit skipped" in message for message in logs)
+    # No wrap means no ``model__`` key prefixing to strip back out.
+    assert result.best_params == {"C": 1.0}
+
+
+def test_halving_wrap_kept_for_shape_preserving_preprocessing(monkeypatch):
+    estimator, logs, _result = _tune_with_spied_halving_build(
+        monkeypatch, _StubPreprocessor(changes_row_count=False)
+    )
+    assert isinstance(estimator, Pipeline)
+    assert not any("Per-fold preprocessing refit skipped" in message for message in logs)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_fold_preprocessing_refit.py
+++ b/tests/integration/test_fold_preprocessing_refit.py
@@ -2,9 +2,11 @@
 
 The app threads a ``FeatureEngineerFoldAdapter`` + pre-transform train payload
 into every tuning/CV run so preprocessing statistics never see held-out fold
-rows. Graphs the hook cannot serve (merged branches, halving/optuna strategies)
-fall back to pre-transformed scoring with an explicit job-log warning — never
-a failed run, never a silent leak.
+rows — all tuning strategies included (halving/optuna get it via a Pipeline
+wrapper around the searcher's internal CV). Graphs the hook cannot serve
+(merged branches, validation-split holdout) fall back to pre-transformed
+scoring with an explicit job-log warning — never a failed run, never a silent
+leak.
 """
 
 import numpy as np
@@ -51,7 +53,7 @@ def _loader(node_id: str, path: str) -> NodeConfig:
     )
 
 
-def _training(inputs: list[str], **extra) -> NodeConfig:
+def _training(inputs: list[str], node_id: str = "node_training", **extra) -> NodeConfig:
     params = {
         "target_column": "target",
         "algorithm": "logistic_regression",
@@ -62,9 +64,7 @@ def _training(inputs: list[str], **extra) -> NodeConfig:
         "evaluate": True,
     }
     params.update(extra)
-    return NodeConfig(
-        node_id="node_training", step_type=StepType.TRAINING, inputs=inputs, params=params
-    )
+    return NodeConfig(node_id=node_id, step_type=StepType.TRAINING, inputs=inputs, params=params)
 
 
 def _run(tmp_path, nodes, job_id):
@@ -264,8 +264,9 @@ def test_leakage_dominated_contrast_end_to_end(noise_target_csv, tmp_path):
     )
 
 
-def test_halving_strategy_falls_back_with_warning(noise_target_csv, tmp_path):
-    """halving_grid delegates CV to sklearn searchers → fallback with an explicit warning."""
+def test_halving_strategy_refits_per_fold(noise_target_csv, tmp_path):
+    """halving_grid runs CV inside the sklearn searcher; the Pipeline wrapper
+    must refit WOE per fold there too, so the noise-target score stays honest."""
     result, logs = _run(
         tmp_path,
         [
@@ -288,11 +289,140 @@ def test_halving_strategy_falls_back_with_warning(noise_target_csv, tmp_path):
                 },
             ),
         ],
-        job_id="f15-halving-fallback",
+        job_id="f15-halving-refit",
     )
 
     assert result.status == "success"
-    assert any("Per-fold preprocessing refit skipped" in m and "halving_grid" in m for m in logs)
+    assert any("Per-fold preprocessing refit enabled" in m for m in logs)
+    metrics = result.node_results["node_training"].metrics
+    assert _disc(metrics["best_score"]) < 0.65, (
+        f"inner halving tuning score should sit near chance, got {metrics['best_score']}"
+    )
+    assert _disc(metrics["cv_roc_auc_mean"]) < 0.65, (
+        f"outer CV score should sit near chance, got {metrics['cv_roc_auc_mean']}"
+    )
+
+
+def test_halving_with_nan_and_imputer_runs_refit(tmp_path):
+    """NaN-bearing features + imputer step through the halving Pipeline wrapper:
+    the NaN gate must let the pre-transform payload through and the run must
+    complete with refit enabled."""
+    rng = np.random.default_rng(3)
+    n = 300
+    num1 = rng.normal(0, 1, n)
+    num2 = rng.normal(0, 1, n)
+    num2[rng.random(n) < 0.15] = np.nan
+    df = pd.DataFrame(
+        {
+            "num1": num1,
+            "num2": num2,
+            "city": [f"c{v}" for v in rng.integers(0, 8, size=n)],
+            "target": rng.integers(0, 2, size=n),
+        }
+    )
+    path = tmp_path / "nan_features.csv"
+    df.to_csv(path, index=False)
+
+    result, logs = _run(
+        tmp_path,
+        [
+            _loader("node_data", str(path)),
+            NodeConfig(
+                node_id="node_features",
+                step_type=StepType.FEATURE_ENGINEERING,
+                inputs=["node_data"],
+                params={
+                    "steps": [
+                        SPLITTER_STEP,
+                        {
+                            "name": "impute_num2",
+                            "transformer": "SimpleImputer",
+                            "params": {"strategy": "mean", "columns": ["num2"]},
+                        },
+                        WOE_STEP,
+                    ]
+                },
+            ),
+            _training(
+                ["node_features"],
+                run_mode="tuned",
+                tuning_config={
+                    "strategy": "halving_grid",
+                    "metric": "roc_auc",
+                    "cv_folds": 2,
+                    "cv_enabled": True,
+                    "search_space": {"C": [1.0]},
+                },
+            ),
+        ],
+        job_id="f15-halving-nan-imputer",
+    )
+
+    assert result.status == "success"
+    assert any("Per-fold preprocessing refit enabled" in m for m in logs)
+    metrics = result.node_results["node_training"].metrics
+    assert np.isfinite(metrics["best_score"])
+
+
+def test_two_independent_pipelines_both_refit(noise_target_csv, tmp_path):
+    """One job, two disjoint loader→FE→training pipelines: each training node
+    resolves its own chain and stays honest independently."""
+    result, logs = _run(
+        tmp_path,
+        [
+            _loader("loader_a", noise_target_csv),
+            _loader("loader_b", noise_target_csv),
+            NodeConfig(
+                node_id="features_a",
+                step_type=StepType.FEATURE_ENGINEERING,
+                inputs=["loader_a"],
+                params={"steps": [SPLITTER_STEP, WOE_STEP]},
+            ),
+            NodeConfig(
+                node_id="features_b",
+                step_type=StepType.FEATURE_ENGINEERING,
+                inputs=["loader_b"],
+                params={"steps": [SPLITTER_STEP, WOE_STEP]},
+            ),
+            _training(
+                ["features_a"],
+                node_id="training_a",
+                run_mode="tuned",
+                tuning_config={
+                    "strategy": "grid",
+                    "metric": "roc_auc",
+                    "cv_folds": 2,
+                    "cv_enabled": True,
+                    "search_space": {"C": [1.0]},
+                },
+            ),
+            _training(
+                ["features_b"],
+                node_id="training_b",
+                run_mode="tuned",
+                tuning_config={
+                    "strategy": "grid",
+                    "metric": "roc_auc",
+                    "cv_folds": 2,
+                    "cv_enabled": True,
+                    "search_space": {"C": [1.0]},
+                },
+            ),
+        ],
+        job_id="f15-two-pipelines",
+    )
+
+    assert result.status == "success"
+    enabled = [m for m in logs if "Per-fold preprocessing refit enabled" in m]
+    assert len(enabled) >= 2, f"expected refit enabled for both branches, logs={logs}"
+    for node_id in ("training_a", "training_b"):
+        metrics = result.node_results[node_id].metrics
+        assert _disc(metrics["best_score"]) < 0.65, (
+            f"{node_id} tuning score should sit near chance, got {metrics['best_score']}"
+        )
+        assert _disc(metrics["cv_roc_auc_mean"]) < 0.65, (
+            f"{node_id} CV score should sit near chance, got {metrics['cv_roc_auc_mean']}"
+        )
 
 
 def test_splitter_only_chain_skips_silently(tmp_path):

--- a/tests/integration/test_fold_preprocessing_refit.py
+++ b/tests/integration/test_fold_preprocessing_refit.py
@@ -15,6 +15,7 @@ import pytest
 
 from backend.data.catalog import FileSystemCatalog
 from backend.ml_pipeline._execution.engine import PipelineEngine
+from backend.ml_pipeline._execution.engine._feature_eng import FeatureEngMixin
 from backend.ml_pipeline._execution.schemas import NodeConfig, PipelineConfig
 from backend.ml_pipeline.artifacts.local import LocalArtifactStore
 from backend.ml_pipeline.constants import StepType
@@ -543,7 +544,11 @@ def test_stateless_step_before_splitter_keeps_refit_enabled(tmp_path):
     )
 
     assert result.status == "success"
-    assert any("Per-fold preprocessing refit enabled" in m for m in logs)
+    enabled = [m for m in logs if "Per-fold preprocessing refit enabled" in m]
+    assert enabled
+    # The stateless pre-split step was already applied during payload
+    # reconstruction; only the post-split WOE step re-fits per fold.
+    assert "1 step(s)" in enabled[0]
     metrics = result.node_results["node_training"].metrics
     assert _disc(metrics["cv_roc_auc_mean"]) < 0.65, (
         f"per-fold refit CV should sit near chance, got {metrics['cv_roc_auc_mean']}"
@@ -706,3 +711,48 @@ def test_validation_split_tuning_falls_back_with_warning(tmp_path):
     assert any(
         "Per-fold preprocessing refit skipped" in m and "validation split" in m for m in logs
     ), f"expected the validation-split fallback warning, logs={logs}"
+
+
+# ---------------------------------------------------------------------------
+# _upstream_fe_chain — graph-shape edge branches
+# ---------------------------------------------------------------------------
+
+
+def _chain_mixin(configs: list[NodeConfig]) -> FeatureEngMixin:
+    mixin = object.__new__(FeatureEngMixin)
+    mixin._node_configs = {cfg.node_id: cfg for cfg in configs}
+    return mixin
+
+
+def test_upstream_chain_rejects_multi_input_training_node():
+    mixin = _chain_mixin([_loader("node_data", "x.csv")])
+    assert mixin._upstream_fe_chain(_training(["a", "b"])) is None
+
+
+def test_upstream_chain_rejects_missing_node_reference():
+    fe = NodeConfig(
+        node_id="node_features",
+        step_type=StepType.FEATURE_ENGINEERING,
+        inputs=["ghost"],
+        params={"steps": []},
+    )
+    mixin = _chain_mixin([fe])
+    assert mixin._upstream_fe_chain(_training(["node_features"])) is None
+
+
+def test_upstream_chain_rejects_unsupported_node_in_between():
+    first = _training(["node_data"], node_id="node_training_a")
+    second = _training(["node_training_a"], node_id="node_training_b")
+    mixin = _chain_mixin([_loader("node_data", "x.csv"), first])
+    assert mixin._upstream_fe_chain(second) is None
+
+
+def test_upstream_chain_rejects_chain_without_loader():
+    fe = NodeConfig(
+        node_id="node_features",
+        step_type=StepType.FEATURE_ENGINEERING,
+        inputs=[],
+        params={"steps": []},
+    )
+    mixin = _chain_mixin([fe])
+    assert mixin._upstream_fe_chain(_training(["node_features"])) is None

--- a/tests/integration/test_fold_preprocessing_refit.py
+++ b/tests/integration/test_fold_preprocessing_refit.py
@@ -455,3 +455,96 @@ def test_splitter_only_chain_skips_silently(tmp_path):
 
     assert result.status == "success"
     assert not any("Per-fold preprocessing refit" in m for m in logs)
+
+
+def test_learning_step_before_splitter_falls_back_with_warning(tmp_path):
+    """A data-dependent step configured BEFORE the splitter cannot be re-fit
+    per fold: payload reconstruction would fit it on the full frame (leaking
+    held-out rows) and the per-fold adapter would apply it twice. The resolver
+    must fall back to pre-transformed scoring with an explicit warning."""
+    rng = np.random.default_rng(11)
+    n = 240
+    df = pd.DataFrame(
+        {
+            "f1": rng.normal(0, 1, n),
+            "f2": rng.normal(0, 1, n),
+            "target": rng.integers(0, 2, size=n),
+        }
+    )
+    path = tmp_path / "numeric_pre_split.csv"
+    df.to_csv(path, index=False)
+
+    result, logs = _run(
+        tmp_path,
+        [
+            _loader("node_data", str(path)),
+            NodeConfig(
+                node_id="node_features",
+                step_type=StepType.FEATURE_ENGINEERING,
+                inputs=["node_data"],
+                params={
+                    "steps": [
+                        {"name": "scale", "transformer": "StandardScaler", "params": {}},
+                        SPLITTER_STEP,
+                    ]
+                },
+            ),
+            _training(["node_features"]),
+        ],
+        job_id="f15-pre-split-learner-fallback",
+    )
+
+    assert result.status == "success"
+    assert any(
+        "Per-fold preprocessing refit skipped" in m and "before the last splitter" in m
+        for m in logs
+    ), f"expected the pre-splitter fallback warning, logs={logs}"
+    assert not any("Per-fold preprocessing refit enabled" in m for m in logs)
+
+
+def test_stateless_step_before_splitter_keeps_refit_enabled(tmp_path):
+    """Param-aware exemption: an explicit-column DropMissingColumns before the
+    splitter learns nothing from the rows, so per-fold refit stays enabled."""
+    rng = np.random.default_rng(7)
+    n, n_categories = 400, 200
+    df = pd.DataFrame(
+        {
+            "id_col": [f"id{i}" for i in range(n)],
+            "city": [f"c{v}" for v in rng.integers(0, n_categories, size=n)],
+            "target": rng.integers(0, 2, size=n),
+        }
+    )
+    path = tmp_path / "noise_with_id.csv"
+    df.to_csv(path, index=False)
+
+    result, logs = _run(
+        tmp_path,
+        [
+            _loader("node_data", str(path)),
+            NodeConfig(
+                node_id="node_features",
+                step_type=StepType.FEATURE_ENGINEERING,
+                inputs=["node_data"],
+                params={
+                    "steps": [
+                        {
+                            "name": "drop_id",
+                            "transformer": "DropMissingColumns",
+                            "params": {"columns": ["id_col"]},
+                        },
+                        SPLITTER_STEP,
+                        WOE_STEP,
+                    ]
+                },
+            ),
+            _training(["node_features"]),
+        ],
+        job_id="f15-stateless-pre-split",
+    )
+
+    assert result.status == "success"
+    assert any("Per-fold preprocessing refit enabled" in m for m in logs)
+    metrics = result.node_results["node_training"].metrics
+    assert _disc(metrics["cv_roc_auc_mean"]) < 0.65, (
+        f"per-fold refit CV should sit near chance, got {metrics['cv_roc_auc_mean']}"
+    )

--- a/tests/integration/test_fold_preprocessing_refit.py
+++ b/tests/integration/test_fold_preprocessing_refit.py
@@ -1,0 +1,327 @@
+"""F-15 backend wiring: always-on per-fold preprocessing refit at engine level.
+
+The app threads a ``FeatureEngineerFoldAdapter`` + pre-transform train payload
+into every tuning/CV run so preprocessing statistics never see held-out fold
+rows. Graphs the hook cannot serve (merged branches, halving/optuna strategies)
+fall back to pre-transformed scoring with an explicit job-log warning — never
+a failed run, never a silent leak.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from backend.data.catalog import FileSystemCatalog
+from backend.ml_pipeline._execution.engine import PipelineEngine
+from backend.ml_pipeline._execution.schemas import NodeConfig, PipelineConfig
+from backend.ml_pipeline.artifacts.local import LocalArtifactStore
+from backend.ml_pipeline.constants import StepType
+
+SPLITTER_STEP = {
+    "name": "split",
+    "transformer": "TrainTestSplitter",
+    "params": {"target_column": "target", "test_size": 0.2},
+}
+WOE_STEP = {
+    "name": "woe_city",
+    "transformer": "WOEEncoder",
+    "params": {"columns": ["city"], "regularization": 0.5},
+}
+
+
+@pytest.fixture
+def noise_target_csv(tmp_path):
+    """400 pure-noise rows / 200 categories: WOE can only 'predict' by memorising."""
+    rng = np.random.default_rng(42)
+    n, n_categories = 400, 200
+    df = pd.DataFrame(
+        {
+            "city": [f"c{v}" for v in rng.integers(0, n_categories, size=n)],
+            "target": rng.integers(0, 2, size=n),
+        }
+    )
+    path = tmp_path / "noise.csv"
+    df.to_csv(path, index=False)
+    return str(path)
+
+
+def _loader(node_id: str, path: str) -> NodeConfig:
+    return NodeConfig(
+        node_id=node_id, step_type=StepType.DATA_LOADER, params={"source": "csv", "path": path}
+    )
+
+
+def _training(inputs: list[str], **extra) -> NodeConfig:
+    params = {
+        "target_column": "target",
+        "algorithm": "logistic_regression",
+        "hyperparameters": {"C": 1.0},
+        "metric": "roc_auc",
+        "cv_enabled": True,
+        "cv_folds": 5,
+        "evaluate": True,
+    }
+    params.update(extra)
+    return NodeConfig(
+        node_id="node_training", step_type=StepType.TRAINING, inputs=inputs, params=params
+    )
+
+
+def _run(tmp_path, nodes, job_id):
+    logs: list[str] = []
+    store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    engine = PipelineEngine(store, catalog=FileSystemCatalog(), log_callback=logs.append)
+    result = engine.run(PipelineConfig(pipeline_id=job_id, nodes=nodes), job_id=job_id)
+    return result, logs
+
+
+def _disc(auc: float) -> float:
+    return max(auc, 1.0 - auc)
+
+
+def test_fe_node_woe_refit_keeps_cv_near_chance(noise_target_csv, tmp_path):
+    """Combined FE node (splitter + WOE): refit is enabled and CV stays near chance.
+
+    The pre-learning train payload is reconstructed by re-running the
+    splitter-only step prefix; the memorising WOE step then refits per fold.
+    """
+    result, logs = _run(
+        tmp_path,
+        [
+            _loader("node_data", noise_target_csv),
+            NodeConfig(
+                node_id="node_features",
+                step_type=StepType.FEATURE_ENGINEERING,
+                inputs=["node_data"],
+                params={"steps": [SPLITTER_STEP, WOE_STEP]},
+            ),
+            _training(["node_features"]),
+        ],
+        job_id="f15-fe-node",
+    )
+
+    assert result.status == "success"
+    assert any("Per-fold preprocessing refit enabled" in m for m in logs)
+    metrics = result.node_results["node_training"].metrics
+    assert "cv_roc_auc_mean" in metrics
+    assert _disc(metrics["cv_roc_auc_mean"]) < 0.65, (
+        f"per-fold refit CV should sit near chance, got {metrics['cv_roc_auc_mean']}"
+    )
+
+
+def test_transformer_chain_refit_keeps_cv_near_chance(noise_target_csv, tmp_path):
+    """Separate splitter + WOE transformer nodes: payload loads from the splitter artifact."""
+    result, logs = _run(
+        tmp_path,
+        [
+            _loader("node_data", noise_target_csv),
+            NodeConfig(
+                node_id="node_split",
+                step_type="TrainTestSplitter",
+                inputs=["node_data"],
+                params={"target_column": "target", "test_size": 0.2},
+            ),
+            NodeConfig(
+                node_id="node_woe",
+                step_type="WOEEncoder",
+                inputs=["node_split"],
+                params={"columns": ["city"], "regularization": 0.5},
+            ),
+            _training(["node_woe"]),
+        ],
+        job_id="f15-transformer-chain",
+    )
+
+    assert result.status == "success"
+    assert any("Per-fold preprocessing refit enabled" in m for m in logs)
+    metrics = result.node_results["node_training"].metrics
+    assert _disc(metrics["cv_roc_auc_mean"]) < 0.65
+
+
+def test_tuned_run_inner_and_outer_scores_both_near_chance(noise_target_csv, tmp_path):
+    """Tuning (inner CV) and the tuned CV (outer) both refit per fold."""
+    result, logs = _run(
+        tmp_path,
+        [
+            _loader("node_data", noise_target_csv),
+            NodeConfig(
+                node_id="node_features",
+                step_type=StepType.FEATURE_ENGINEERING,
+                inputs=["node_data"],
+                params={"steps": [SPLITTER_STEP, WOE_STEP]},
+            ),
+            _training(
+                ["node_features"],
+                run_mode="tuned",
+                tuning_config={
+                    "strategy": "grid",
+                    "metric": "roc_auc",
+                    "cv_folds": 2,
+                    "cv_enabled": True,
+                    "search_space": {"C": [0.1, 1.0]},
+                },
+            ),
+        ],
+        job_id="f15-tuned-inner-outer",
+    )
+
+    assert result.status == "success"
+    assert any("Per-fold preprocessing refit enabled" in m for m in logs)
+    metrics = result.node_results["node_training"].metrics
+    assert _disc(metrics["best_score"]) < 0.65, (
+        f"inner tuning score should sit near chance, got {metrics['best_score']}"
+    )
+    assert _disc(metrics["cv_roc_auc_mean"]) < 0.65, (
+        f"outer CV score should sit near chance, got {metrics['cv_roc_auc_mean']}"
+    )
+
+
+def test_merged_branches_fall_back_with_warning(noise_target_csv, tmp_path):
+    """A merge upstream of training disables the hook with an explicit warning."""
+    result, logs = _run(
+        tmp_path,
+        [
+            _loader("loader_a", noise_target_csv),
+            _loader("loader_b", noise_target_csv),
+            NodeConfig(
+                node_id="node_features",
+                step_type=StepType.FEATURE_ENGINEERING,
+                inputs=["loader_a", "loader_b"],
+                params={"steps": [SPLITTER_STEP, WOE_STEP]},
+            ),
+            _training(["node_features"]),
+        ],
+        job_id="f15-merge-fallback",
+    )
+
+    assert result.status == "success"
+    assert any("Per-fold preprocessing refit skipped" in m and "linear chain" in m for m in logs)
+
+
+def test_leakage_dominated_contrast_end_to_end(noise_target_csv, tmp_path):
+    """The leakage-dominated case, measured both ways on the same CSV.
+
+    Leaky (pre-F-15 scoring, still what every fallback path reports): WOE is
+    fitted once on the full training split, then CV scores the transformed
+    data — every fold's validation rows shaped the encoding, so the noise
+    target is memorised and AUC inflates far above chance (measured ~0.87).
+
+    Leak-free (the app's always-on refit path): the identical pipeline
+    through the engine re-fits WOE inside every fold and sits at chance.
+    """
+    from sklearn.model_selection import train_test_split
+
+    from skyulf.modeling.classification import (
+        LogisticRegressionApplier,
+        LogisticRegressionCalculator,
+    )
+    from skyulf.modeling.cross_validation import perform_cross_validation
+    from skyulf.preprocessing.encoding import WOEEncoderApplier, WOEEncoderCalculator
+
+    # --- Leaky control: the pre-F-15 scoring discipline on the same CSV. ---
+    frame = pd.read_csv(noise_target_csv)
+    X = frame.drop(columns=["target"])
+    y = frame["target"]
+    X_train, _X_test, y_train, _y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    leaky_params = WOEEncoderCalculator().fit((X_train, y_train), WOE_STEP["params"])
+    X_leaky, _ = WOEEncoderApplier().apply((X_train, y_train), dict(leaky_params))
+    leaky_cv = perform_cross_validation(
+        LogisticRegressionCalculator(),
+        LogisticRegressionApplier(),
+        X_leaky,
+        y_train,
+        config={},
+        n_folds=5,
+        cv_type="k_fold",
+    )
+    auc_leaky = leaky_cv["aggregated_metrics"]["roc_auc"]["mean"]
+    assert _disc(auc_leaky) > 0.75, (
+        f"legacy full-fit scoring should memorise the noise target, got {auc_leaky}"
+    )
+
+    # --- Leak-free: the identical pipeline through the app engine. ---
+    result, logs = _run(
+        tmp_path,
+        [
+            _loader("node_data", noise_target_csv),
+            NodeConfig(
+                node_id="node_features",
+                step_type=StepType.FEATURE_ENGINEERING,
+                inputs=["node_data"],
+                params={"steps": [SPLITTER_STEP, WOE_STEP]},
+            ),
+            _training(["node_features"]),
+        ],
+        job_id="f15-leakage-contrast",
+    )
+
+    assert result.status == "success"
+    assert any("Per-fold preprocessing refit enabled" in m for m in logs)
+    auc_refit = result.node_results["node_training"].metrics["cv_roc_auc_mean"]
+    assert _disc(auc_refit) < 0.65, f"per-fold refit CV should sit near chance, got {auc_refit}"
+    assert _disc(auc_leaky) - _disc(auc_refit) > 0.10, (
+        f"expected a large leak gap, got leaky={auc_leaky} vs refit={auc_refit}"
+    )
+
+
+def test_halving_strategy_falls_back_with_warning(noise_target_csv, tmp_path):
+    """halving_grid delegates CV to sklearn searchers → fallback with an explicit warning."""
+    result, logs = _run(
+        tmp_path,
+        [
+            _loader("node_data", noise_target_csv),
+            NodeConfig(
+                node_id="node_features",
+                step_type=StepType.FEATURE_ENGINEERING,
+                inputs=["node_data"],
+                params={"steps": [SPLITTER_STEP, WOE_STEP]},
+            ),
+            _training(
+                ["node_features"],
+                run_mode="tuned",
+                tuning_config={
+                    "strategy": "halving_grid",
+                    "metric": "roc_auc",
+                    "cv_folds": 2,
+                    "cv_enabled": True,
+                    "search_space": {"C": [0.1, 1.0]},
+                },
+            ),
+        ],
+        job_id="f15-halving-fallback",
+    )
+
+    assert result.status == "success"
+    assert any("Per-fold preprocessing refit skipped" in m and "halving_grid" in m for m in logs)
+
+
+def test_splitter_only_chain_skips_silently(tmp_path):
+    """Only a splitter upstream: nothing data-dependent to refit, no warning needed."""
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame(
+        {
+            "f1": rng.uniform(0, 10, size=120),
+            "f2": rng.uniform(0, 10, size=120),
+            "target": rng.integers(0, 2, size=120),
+        }
+    )
+    path = tmp_path / "numeric.csv"
+    df.to_csv(path, index=False)
+
+    result, logs = _run(
+        tmp_path,
+        [
+            _loader("node_data", str(path)),
+            NodeConfig(
+                node_id="node_split",
+                step_type="TrainTestSplitter",
+                inputs=["node_data"],
+                params={"target_column": "target", "test_size": 0.2},
+            ),
+            _training(["node_split"]),
+        ],
+        job_id="f15-splitter-only",
+    )
+
+    assert result.status == "success"
+    assert not any("Per-fold preprocessing refit" in m for m in logs)

--- a/tests/integration/test_fold_preprocessing_refit.py
+++ b/tests/integration/test_fold_preprocessing_refit.py
@@ -548,3 +548,161 @@ def test_stateless_step_before_splitter_keeps_refit_enabled(tmp_path):
     assert _disc(metrics["cv_roc_auc_mean"]) < 0.65, (
         f"per-fold refit CV should sit near chance, got {metrics['cv_roc_auc_mean']}"
     )
+
+
+# ---------------------------------------------------------------------------
+# _step_learns_from_data — the resolver's per-step verdict
+# ---------------------------------------------------------------------------
+
+
+def test_step_learns_from_data_mirrors_the_leakage_gate():
+    from backend.ml_pipeline._execution.engine._feature_eng import _step_learns_from_data
+
+    # Param-aware stateless exemptions.
+    assert not _step_learns_from_data(
+        {"transformer": "SimpleImputer", "params": {"strategy": "constant"}}
+    )
+    assert not _step_learns_from_data(
+        {"transformer": "MissingIndicator", "params": {"columns": ["x"]}}
+    )
+    assert not _step_learns_from_data({"transformer": "HashEncoder", "params": {"columns": ["x"]}})
+    assert not _step_learns_from_data(
+        {"transformer": "DropMissingColumns", "params": {"columns": ["id"]}}
+    )
+    # Data-dependent modes of the same nodes, and plain learners.
+    assert _step_learns_from_data({"transformer": "SimpleImputer", "params": {"strategy": "mean"}})
+    assert _step_learns_from_data(
+        {"transformer": "DropMissingColumns", "params": {"missing_threshold": 50}}
+    )
+    assert _step_learns_from_data({"transformer": "StandardScaler", "params": {}})
+    # Registered but stateless node.
+    assert not _step_learns_from_data({"transformer": "DropMissingRows", "params": {}})
+    # Unknown transformers fail closed.
+    assert _step_learns_from_data({"transformer": "NoSuchNode", "params": {}})
+
+
+# ---------------------------------------------------------------------------
+# Remaining resolver branches: no-split payload, reconstruction failure,
+# validation-split holdout tuning
+# ---------------------------------------------------------------------------
+
+
+def test_no_split_chain_refits_from_the_raw_loader_frame(tmp_path):
+    """No splitter upstream: the raw loader frame is the pre-transform payload
+    and the learning step refits per fold."""
+    rng = np.random.default_rng(13)
+    n = 240
+    df = pd.DataFrame(
+        {
+            "f1": rng.normal(0, 1, n),
+            "f2": rng.normal(0, 1, n),
+            "target": rng.integers(0, 2, size=n),
+        }
+    )
+    path = tmp_path / "no_split.csv"
+    df.to_csv(path, index=False)
+
+    result, logs = _run(
+        tmp_path,
+        [
+            _loader("node_data", str(path)),
+            NodeConfig(
+                node_id="node_features",
+                step_type=StepType.FEATURE_ENGINEERING,
+                inputs=["node_data"],
+                params={
+                    "steps": [{"name": "scale", "transformer": "StandardScaler", "params": {}}]
+                },
+            ),
+            _training(["node_features"]),
+        ],
+        job_id="f15-no-split-payload",
+    )
+
+    assert result.status == "success"
+    assert any("Per-fold preprocessing refit enabled" in m for m in logs)
+
+
+def test_payload_reconstruction_failure_never_fails_the_run(
+    noise_target_csv, tmp_path, monkeypatch
+):
+    """If payload reconstruction raises, the resolver must swallow the error,
+    warn explicitly, and let the job finish on pre-transformed scoring."""
+    from backend.ml_pipeline._execution.engine._feature_eng import FeatureEngMixin
+
+    def boom(self, output, target_col):
+        raise RuntimeError("simulated artifact corruption")
+
+    monkeypatch.setattr(FeatureEngMixin, "_split_train_payload", boom)
+
+    result, logs = _run(
+        tmp_path,
+        [
+            _loader("node_data", noise_target_csv),
+            NodeConfig(
+                node_id="node_features",
+                step_type=StepType.FEATURE_ENGINEERING,
+                inputs=["node_data"],
+                params={"steps": [SPLITTER_STEP, WOE_STEP]},
+            ),
+            _training(["node_features"]),
+        ],
+        job_id="f15-reconstruction-failure",
+    )
+
+    assert result.status == "success"
+    assert any(
+        "Per-fold preprocessing refit skipped" in m and "payload reconstruction failed" in m
+        for m in logs
+    ), f"expected the reconstruction-failure warning, logs={logs}"
+
+
+def test_validation_split_tuning_falls_back_with_warning(tmp_path):
+    """Holdout tuning with a validation split cannot refit per fold (the
+    tuning engine rejects the hook alongside validation_data); the runner
+    skips the hook with an explicit log instead of failing."""
+    rng = np.random.default_rng(17)
+    n = 240
+    df = pd.DataFrame(
+        {
+            "f1": rng.normal(0, 1, n),
+            "f2": rng.normal(0, 1, n),
+            "target": rng.integers(0, 2, size=n),
+        }
+    )
+    path = tmp_path / "validation_split.csv"
+    df.to_csv(path, index=False)
+
+    result, logs = _run(
+        tmp_path,
+        [
+            _loader("node_data", str(path)),
+            NodeConfig(
+                node_id="node_split",
+                step_type="TrainTestSplitter",
+                inputs=["node_data"],
+                params={
+                    "target_column": "target",
+                    "test_size": 0.2,
+                    "validation_size": 0.2,
+                },
+            ),
+            _training(
+                ["node_split"],
+                run_mode="tuned",
+                tuning_config={
+                    "strategy": "grid",
+                    "metric": "roc_auc",
+                    "cv_folds": 2,
+                    "cv_enabled": True,
+                    "search_space": {"C": [0.1, 1.0]},
+                },
+            ),
+        ],
+        job_id="f15-validation-split-fallback",
+    )
+
+    assert result.status == "success"
+    assert any(
+        "Per-fold preprocessing refit skipped" in m and "validation split" in m for m in logs
+    ), f"expected the validation-split fallback warning, logs={logs}"

--- a/tests/integration/test_fold_preprocessing_stress.py
+++ b/tests/integration/test_fold_preprocessing_stress.py
@@ -1,0 +1,254 @@
+"""F-15 stress coverage: rich preprocessing chains across model families.
+
+Complements ``test_fold_preprocessing_refit.py`` (mechanism proofs with one
+narrow WOE + logistic-regression setup) by exercising the always-on refit
+through a realistic chain — imputation, scaling and target-aware encoding —
+across classification, regression and ensemble algorithms, and by re-checking
+score honesty on noise targets for a regressor and a tree ensemble.
+"""
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from backend.data.catalog import FileSystemCatalog
+from backend.ml_pipeline._execution.engine import PipelineEngine
+from backend.ml_pipeline._execution.schemas import NodeConfig, PipelineConfig
+from backend.ml_pipeline.artifacts.local import LocalArtifactStore
+from backend.ml_pipeline.constants import StepType
+
+SPLITTER_STEP = {
+    "name": "split",
+    "transformer": "TrainTestSplitter",
+    "params": {"target_column": "target", "test_size": 0.2},
+}
+IMPUTE_STEP = {
+    "name": "impute_num2",
+    "transformer": "SimpleImputer",
+    "params": {"strategy": "mean", "columns": ["num2"]},
+}
+SCALE_STEP = {
+    "name": "scale",
+    "transformer": "StandardScaler",
+    "params": {"columns": ["num1", "num2"]},
+}
+CLF_STEPS = [
+    SPLITTER_STEP,
+    IMPUTE_STEP,
+    SCALE_STEP,
+    {
+        "name": "woe_cat",
+        "transformer": "WOEEncoder",
+        "params": {"columns": ["cat"], "regularization": 0.5},
+    },
+]
+REG_STEPS = [
+    SPLITTER_STEP,
+    IMPUTE_STEP,
+    SCALE_STEP,
+    {
+        "name": "target_encode_cat",
+        "transformer": "TargetEncoder",
+        "params": {"columns": ["cat"], "target_column": "target"},
+    },
+]
+
+
+def _write_csv(tmp_path, df, name):
+    path = tmp_path / name
+    df.to_csv(path, index=False)
+    return str(path)
+
+
+@pytest.fixture
+def signal_clf_csv(tmp_path):
+    """Signal-bearing classification frame: NaN column + 10-category feature."""
+    rng = np.random.default_rng(7)
+    n = 400
+    num1 = rng.normal(0, 1, n)
+    num2 = rng.normal(0, 1, n)
+    num2[rng.random(n) < 0.1] = np.nan
+    df = pd.DataFrame(
+        {
+            "num1": num1,
+            "num2": num2,
+            "cat": [f"c{v}" for v in rng.integers(0, 10, size=n)],
+            "target": (num1 + rng.normal(0, 0.5, n) > 0).astype(int),
+        }
+    )
+    return _write_csv(tmp_path, df, "clf.csv")
+
+
+@pytest.fixture
+def signal_reg_csv(tmp_path):
+    rng = np.random.default_rng(11)
+    n = 400
+    num1 = rng.normal(0, 1, n)
+    num2 = rng.normal(0, 1, n)
+    num2[rng.random(n) < 0.1] = np.nan
+    df = pd.DataFrame(
+        {
+            "num1": num1,
+            "num2": num2,
+            "cat": [f"c{v}" for v in rng.integers(0, 10, size=n)],
+            "target": 3.0 * num1 + rng.normal(0, 1.0, n),
+        }
+    )
+    return _write_csv(tmp_path, df, "reg.csv")
+
+
+@pytest.fixture
+def noise_reg_csv(tmp_path):
+    """Same features, pure-noise continuous target: TargetEncoder can only
+    'predict' it by leaking validation rows into its per-category means."""
+    rng = np.random.default_rng(13)
+    n = 400
+    num1 = rng.normal(0, 1, n)
+    num2 = rng.normal(0, 1, n)
+    df = pd.DataFrame(
+        {
+            "num1": num1,
+            "num2": num2,
+            "cat": [f"c{v}" for v in rng.integers(0, 200, size=n)],
+            "target": rng.normal(0, 1, n),
+        }
+    )
+    return _write_csv(tmp_path, df, "noise_reg.csv")
+
+
+def _loader(node_id, path):
+    return NodeConfig(
+        node_id=node_id, step_type=StepType.DATA_LOADER, params={"source": "csv", "path": path}
+    )
+
+
+def _training(inputs, algorithm, hyperparameters, metric):
+    return NodeConfig(
+        node_id="node_training",
+        step_type=StepType.TRAINING,
+        inputs=inputs,
+        params={
+            "target_column": "target",
+            "algorithm": algorithm,
+            "hyperparameters": hyperparameters,
+            "metric": metric,
+            "cv_enabled": True,
+            "cv_folds": 3,
+            "evaluate": True,
+        },
+    )
+
+
+def _run(tmp_path, csv_path, steps, training, job_id):
+    logs: list[str] = []
+    store = LocalArtifactStore(str(tmp_path / "artifacts"))
+    engine = PipelineEngine(store, catalog=FileSystemCatalog(), log_callback=logs.append)
+    result = engine.run(
+        PipelineConfig(
+            pipeline_id=job_id,
+            nodes=[
+                _loader("node_data", csv_path),
+                NodeConfig(
+                    node_id="node_features",
+                    step_type=StepType.FEATURE_ENGINEERING,
+                    inputs=["node_data"],
+                    params={"steps": steps},
+                ),
+                training,
+            ],
+        ),
+        job_id=job_id,
+    )
+    return result, logs
+
+
+CLASSIFIERS = [
+    ("logistic_regression", {"C": 1.0}),
+    ("random_forest_classifier", {"n_estimators": 20, "random_state": 42}),
+    ("gradient_boosting_classifier", {"n_estimators": 20, "random_state": 42}),
+    (
+        "voting_classifier",
+        {"base_estimators": ["logistic_regression", "random_forest"]},
+    ),
+    (
+        "stacking_classifier",
+        {"base_estimators": ["logistic_regression", "random_forest"]},
+    ),
+]
+
+
+@pytest.mark.parametrize("algorithm,hyperparameters", CLASSIFIERS)
+def test_classification_chain_refit_scores_real_signal(
+    signal_clf_csv, tmp_path, algorithm, hyperparameters
+):
+    """Imputer + scaler + WOE chain refit per fold; signal must survive it."""
+    training = _training(["node_features"], algorithm, hyperparameters, "roc_auc")
+    result, logs = _run(
+        tmp_path, signal_clf_csv, CLF_STEPS, training, f"f15-stress-clf-{algorithm}"
+    )
+
+    assert result.status == "success"
+    assert any("Per-fold preprocessing refit enabled" in m for m in logs)
+    metrics = result.node_results["node_training"].metrics
+    auc = metrics["cv_roc_auc_mean"]
+    assert math.isfinite(auc) and auc > 0.65, f"{algorithm}: expected real signal, got {auc}"
+
+
+REGRESSORS = [
+    ("ridge_regression", {}),
+    ("gradient_boosting_regressor", {"n_estimators": 20, "random_state": 42}),
+    ("voting_regressor", {"base_estimators": ["ridge", "random_forest"]}),
+]
+
+
+@pytest.mark.parametrize("algorithm,hyperparameters", REGRESSORS)
+def test_regression_chain_refit_scores_real_signal(
+    signal_reg_csv, tmp_path, algorithm, hyperparameters
+):
+    """Imputer + scaler + TargetEncoder chain refit per fold for regressors."""
+    training = _training(["node_features"], algorithm, hyperparameters, "r2")
+    result, logs = _run(
+        tmp_path, signal_reg_csv, REG_STEPS, training, f"f15-stress-reg-{algorithm}"
+    )
+
+    assert result.status == "success"
+    assert any("Per-fold preprocessing refit enabled" in m for m in logs)
+    metrics = result.node_results["node_training"].metrics
+    r2 = metrics["cv_r2_mean"]
+    assert math.isfinite(r2) and r2 > 0.5, f"{algorithm}: expected real signal, got {r2}"
+
+
+def test_regression_noise_target_stays_near_zero(noise_reg_csv, tmp_path):
+    """Honesty probe for the regression path: leaky TargetEncoder memorises
+    per-category noise means and inflates R^2; per-fold refit keeps it ~0."""
+    training = _training(["node_features"], "ridge_regression", {}, "r2")
+    result, logs = _run(tmp_path, noise_reg_csv, REG_STEPS, training, "f15-stress-noise-reg")
+
+    assert result.status == "success"
+    assert any("Per-fold preprocessing refit enabled" in m for m in logs)
+    r2 = result.node_results["node_training"].metrics["cv_r2_mean"]
+    assert r2 < 0.15, f"per-fold refit R^2 on noise should sit near zero, got {r2}"
+
+
+def test_random_forest_noise_target_stays_near_chance(noise_reg_csv, tmp_path):
+    """Honesty probe through a tree ensemble on the classification noise trick:
+    a memorising WOE step + forest on noise must stay near chance."""
+    rng = np.random.default_rng(17)
+    df = pd.read_csv(noise_reg_csv)
+    df["target"] = rng.integers(0, 2, size=len(df))
+    path = _write_csv(tmp_path, df, "noise_clf.csv")
+
+    training = _training(
+        ["node_features"],
+        "random_forest_classifier",
+        {"n_estimators": 20, "random_state": 42},
+        "roc_auc",
+    )
+    result, logs = _run(tmp_path, path, CLF_STEPS, training, "f15-stress-noise-clf")
+
+    assert result.status == "success"
+    assert any("Per-fold preprocessing refit enabled" in m for m in logs)
+    auc = result.node_results["node_training"].metrics["cv_roc_auc_mean"]
+    assert max(auc, 1.0 - auc) < 0.65, f"forest on noise should sit near chance, got {auc}"

--- a/tests/integration/test_merge_scenarios_e2e.py
+++ b/tests/integration/test_merge_scenarios_e2e.py
@@ -75,7 +75,7 @@ def _summarize_artifact(art: Any) -> dict[str, Any]:
 def _dump(scenario: str, payload: dict[str, Any]) -> Path:
     ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
     target = ARTIFACT_DIR / f"{scenario}.json"
-    target.write_text(json.dumps(payload, indent=2, default=str))
+    target.write_text(json.dumps(payload, indent=2, default=str) + "\n", newline="\n")
     return target
 
 


### PR DESCRIPTION
<!-- © 2025 Murat Unsal — Skyulf Project -->

## Summary

Describe the change and what it improves for users.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs only
- [x] Refactor/maintenance

## Checklist

- [ ] Code builds and basic tests pass locally (or in CI)
- [ ] Added/updated tests where appropriate
- [ ] Backend param/enum changes are mirrored in `frontend/ml-canvas/src/modules/nodes/`
- [ ] Updated `changelog/` and docs/README where appropriate
- [ ] No secrets or sensitive data committed
- [ ] All commits are signed off (DCO) with `git commit -s`

## How was this verified?

Describe the commands, tests, or manual checks you ran, and what they showed
(e.g. `uv run pytest tests -q` — 1316 passed; or a before/after screenshot).
Evidence over assertions: a fix without a failing-test-first note or a
reproduction check is harder to review.

## Screenshots or demo (optional)

## Related issues

Fixes #

## Summary by Sourcery

Eliminate preprocessing leakage from cross-validation and hyperparameter-tuning scores by refitting eligible preprocessing steps within each fold and providing explicit fallbacks for unsupported pipeline shapes.

New Features:
- Add per-fold preprocessing refitting to cross-validation and hyperparameter tuning so preprocessing statistics are learned only from each fold’s training data.
- Support leakage-safe preprocessing across all tuning strategies, including searcher-backed halving and Optuna workflows.

Bug Fixes:
- Prevent optimistic CV and tuning scores caused by preprocessing leakage from held-out fold rows.
- Keep fold preprocessing and model data aligned while handling row- or target-changing transformations with safe fallbacks.

Enhancements:
- Automatically resolve upstream preprocessing chains in the pipeline engine and provide explicit logs when refitting is enabled or skipped.
- Expose reusable FoldPreprocessor and FeatureEngineerFoldAdapter APIs for library-level CV and tuning integration.
- Relax tuning input validation for legitimate pre-transform missing values when an imputer is refit within each fold.

Build:
- Bump skyulf-core from 0.6.1 to 0.7.0.

Documentation:
- Document per-fold preprocessing refitting, its fallback behavior, and the resulting change in reported scores.
- Mark the F-15 per-fold refit design as shipped and update the leakage proof example to cover CV and tuning.

Tests:
- Add unit, integration, end-to-end, leakage-proof, and stress coverage for fold-isolated preprocessing across CV, nested CV, tuning strategies, model families, and data engines.

Chores:
- Update changelog entries for the per-fold preprocessing release.